### PR TITLE
Add configuration for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,55 @@
+language: rust
+cache: cargo
+env: # required for allow_failures
+rust:
+  - stable
+  - beta
+  - nightly
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: NAME='cargo-travis'
+  include:
+    - rust: nightly-2018-06-18
+      env: # use env so updating versions causes cache invalidation
+        - CLIPPY_VERSION=0.0.208
+      before_script:
+        - rustup component add rustfmt-preview
+        - cargo install clippy --version $CLIPPY_VERSION || echo "clippy already installed"
+      script:
+        - cargo fmt -- --check
+        - cargo clippy -- -D clippy
+    - env: NAME='cargo-travis'
+      sudo: required # travis-ci/travis-ci#9061
+      before_script:
+        - cargo install cargo-update || ehco "cargo-update already installed"
+        - cargo install cargo-travis || echo "cargo-travis already installed"
+        - cargo install-update -a
+      script:
+        - |
+          cargo build    --verbose &&
+          cargo coverage --verbose &&
+          bash <(curl -s https://codecov.io/bash) -s target/kcov
+        - |
+          cargo doc --verbose &&
+          cargo doc-upload
+      addons: # required for kcov
+        apt:
+          packages:
+            - libcurl4-openssl-dev
+            - libelf-dev
+            - libdw-dev
+            - binutils-dev
+            - cmake
+
+script: |
+  cargo build --verbose &&
+  cargo test  --verbose &&
+  cargo doc   --verbose
+
+branches:
+  only:
+    - staging # bors r+
+    - trying  # bors try
+    - master

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,12 +26,12 @@
 //! }
 //! ```
 
-use std::process::{Command, Output};
-use std::io::{Result, Error, ErrorKind};
 use std::default::Default;
-use std::fmt;
-use std::str::FromStr;
 use std::error;
+use std::fmt;
+use std::io::{Error, ErrorKind, Result};
+use std::process::{Command, Output};
+use std::str::FromStr;
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 /// Browser types available
@@ -52,7 +52,7 @@ pub enum Browser {
     Opera,
 
     ///Mac OS Safari
-    Safari
+    Safari,
 }
 
 ///The Error type for parsing a string into a Browser.
@@ -101,7 +101,7 @@ impl FromStr for Browser {
             "chrome" => Ok(Browser::Chrome),
             "opera" => Ok(Browser::Opera),
             "safari" => Ok(Browser::Safari),
-            _ => Err(ParseBrowserError)
+            _ => Err(ParseBrowserError),
         }
     }
 }
@@ -153,8 +153,8 @@ fn open_browser_internal(browser: Browser, url: &str) -> Result<Output> {
         Browser::Default => Command::new("cmd").arg("/C").arg("start").arg(url).output(),
         _ => Err(Error::new(
             ErrorKind::NotFound,
-            "Only the default browser is supported on this platform right now"
-        ))
+            "Only the default browser is supported on this platform right now",
+        )),
     }
 }
 
@@ -171,11 +171,14 @@ fn open_browser_internal(browser: Browser, url: &str) -> Result<Output> {
                 Browser::Chrome => Some("Google Chrome"),
                 Browser::Opera => Some("Opera"),
                 Browser::Safari => Some("Safari"),
-                _ => None
+                _ => None,
             };
             match app {
                 Some(name) => cmd.arg("-a").arg(name).arg(url).output(),
-                None => Err(Error::new(ErrorKind::NotFound, format!("Unsupported browser {:?}", browser)))
+                None => Err(Error::new(
+                    ErrorKind::NotFound,
+                    format!("Unsupported browser {:?}", browser),
+                )),
             }
         }
     }
@@ -192,25 +195,30 @@ fn open_browser_internal(browser: Browser, url: &str) -> Result<Output> {
 fn open_browser_internal(browser: Browser, url: &str) -> Result<Output> {
     match browser {
         Browser::Default => open_on_linux_using_browser_env(url)
-            .or_else(|_| -> Result<Output> {Command::new("xdg-open").arg(url).output()})
-            .or_else(|_| -> Result<Output> {Command::new("gvfs-open").arg(url).output()})
-            .or_else(|_| -> Result<Output> {Command::new("gnome-open").arg(url).output()}),
+            .or_else(|_| -> Result<Output> { Command::new("xdg-open").arg(url).output() })
+            .or_else(|_| -> Result<Output> { Command::new("gvfs-open").arg(url).output() })
+            .or_else(|_| -> Result<Output> { Command::new("gnome-open").arg(url).output() }),
         _ => Err(Error::new(
-                ErrorKind::NotFound,
-                "Only the default browser is supported on this platform right now"
-            ))
+            ErrorKind::NotFound,
+            "Only the default browser is supported on this platform right now",
+        )),
     }
 }
 
 /// Open on Linux using the $BROWSER env var
 #[cfg(target_os = "linux")]
 fn open_on_linux_using_browser_env(url: &str) -> Result<Output> {
-    let browsers = ::std::env::var("BROWSER").map_err(|_| -> Error { Error::new(ErrorKind::NotFound, format!("BROWSER env not set")) })?;
-    for browser in browsers.split(':') { // $BROWSER can contain ':' delimited options, each representing a potential browser command line
+    let browsers = ::std::env::var("BROWSER")
+        .map_err(|_| -> Error { Error::new(ErrorKind::NotFound, format!("BROWSER env not set")) })?;
+    for browser in browsers.split(':') {
+        // $BROWSER can contain ':' delimited options, each representing a potential browser command line
         if !browser.is_empty() {
             // each browser command can have %s to represent URL, while %c needs to be replaced
             // with ':' and %% with '%'
-            let cmdline = browser.replace("%s", url).replace("%c", ":").replace("%%", "%");
+            let cmdline = browser
+                .replace("%s", url)
+                .replace("%c", ":")
+                .replace("%%", "%");
             let cmdarr: Vec<&str> = cmdline.split_whitespace().collect();
             let mut cmd = Command::new(&cmdarr[0]);
             if cmdarr.len() > 1 {
@@ -225,7 +233,10 @@ fn open_on_linux_using_browser_env(url: &str) -> Result<Output> {
             }
         }
     }
-    return Err(Error::new(ErrorKind::NotFound, "No valid command in $BROWSER"));
+    return Err(Error::new(
+        ErrorKind::NotFound,
+        "No valid command in $BROWSER",
+    ));
 }
 
 #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! ```
 //! use webbrowser;
-//! 
+//!
 //! if webbrowser::open("http://github.com").is_ok() {
 //!     // ...
 //! }
@@ -205,7 +205,7 @@ fn open_browser_internal(browser: Browser, url: &str) -> Result<Output> {
 /// Open on Linux using the $BROWSER env var
 #[cfg(target_os = "linux")]
 fn open_on_linux_using_browser_env(url: &str) -> Result<Output> {
-    let browsers = env::var("BROWSER").map_err(|_| -> Error { Error::new(ErrorKind::NotFound, format!("BROWSER env not set")) })?;
+    let browsers = ::std::env::var("BROWSER").map_err(|_| -> Error { Error::new(ErrorKind::NotFound, format!("BROWSER env not set")) })?;
     for browser in browsers.split(':') { // $BROWSER can contain ':' delimited options, each representing a potential browser command line
         if !browser.is_empty() {
             // each browser command can have %s to represent URL, while %c needs to be replaced


### PR DESCRIPTION
This is my strong opinion and I hope it doesn't come across as an imposition: CI like this would have helped you realize that things were broken on Linux before cutting a 0.3 release! This is definitely YOUR crate, though, and it's your call whether or not this is appropriate for the development you do here. That's not a wrong decision either!

This Travis config is borrowed from the [`great-ci`](https://github.com/CAD97/great-ci) repo. Some functionalities you may not actually want even if you decide you want to accept this form of CI generally might be:

* Code coverage analysis
* Putting docs into a `gh-pages` branch

...which can easily be removed, no worries! 😄 

This PR has a soft dependency on PR #9 -- N.B that CI **will** break without that pass. :)