### PR TITLE
Escape URLs on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,16 @@ matrix:
     - cargo update
     - cargo test --all --locked --verbose
     - cargo doc --verbose
-    - rustup component add rustfmt
+    - rustup component add clippy rustfmt
+    - cargo clippy --all-targets -- -D warnings
     - cargo fmt --all -- --check
 
   - rust: nightly
     script:
     - cargo update
     - cargo test --locked
-    - rustup component add rustfmt
+    - rustup component add clippy rustfmt
+    - cargo clippy --all-targets -- -D warnings
     - cargo fmt --all -- --check
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,14 @@ matrix:
     - cargo update
     - cargo test --all --locked --verbose
     - cargo doc --verbose
-    - rustup component add rustfmt-preview
-    - cargo fmt -- --write-mode=diff
+    - rustup component add rustfmt
+    - cargo fmt --all -- --check
 
   - rust: nightly
     script:
     - cargo update
     - cargo test --locked
-    - rustup component add rustfmt-preview
+    - rustup component add rustfmt
     - cargo fmt --all -- --check
 
 branches:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,7 @@ repository = "https://github.com/amodm/webbrowser-rs"
 readme = "README.md"
 keywords = ["webbrowser", "browser"]
 license = "MIT OR Apache-2.0"
+edition = "2015"
 
-[dependencies]
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3.6", features = ["combaseapi", "objbase", "shellapi", "winerror"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! # Examples
 //!
-//! ```
+//! ```no_run
 //! use webbrowser;
 //!
 //! if webbrowser::open("http://github.com").is_ok() {
@@ -112,14 +112,14 @@ impl FromStr for Browser {
 /// there was an error in running the command, or if the browser was not found.
 ///
 /// Equivalent to:
-/// ```
+/// ```no_run
 /// # use webbrowser::{Browser, open_browser};
 /// # let url = "http://example.com";
 /// open_browser(Browser::Default, url);
 /// ```
 ///
 /// # Examples
-/// ```
+/// ```no_run
 /// use webbrowser;
 ///
 /// if webbrowser::open("http://github.com").is_ok() {
@@ -134,7 +134,7 @@ pub fn open(url: &str) -> Result<Output> {
 /// the same as for [open](fn.open.html).
 ///
 /// # Examples
-/// ```
+/// ```no_run
 /// use webbrowser::{open_browser, Browser};
 ///
 /// if open_browser(Browser::Firefox, "http://github.com").is_ok() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,9 +259,8 @@ fn open_browser_internal(browser: Browser, url: &str) -> Result<Output> {
 /// Open on Linux using the $BROWSER env var
 #[cfg(target_os = "linux")]
 fn open_on_linux_using_browser_env(url: &str) -> Result<Output> {
-    let browsers = ::std::env::var("BROWSER").map_err(|_| -> Error {
-        Error::new(ErrorKind::NotFound, format!("BROWSER env not set"))
-    })?;
+    let browsers = ::std::env::var("BROWSER")
+        .map_err(|_| -> Error { Error::new(ErrorKind::NotFound, "BROWSER env not set") })?;
     for browser in browsers.split(':') {
         // $BROWSER can contain ':' delimited options, each representing a potential browser command line
         if !browser.is_empty() {
@@ -285,10 +284,10 @@ fn open_on_linux_using_browser_env(url: &str) -> Result<Output> {
             }
         }
     }
-    return Err(Error::new(
+    Err(Error::new(
         ErrorKind::NotFound,
         "No valid command in $BROWSER",
-    ));
+    ))
 }
 
 #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,8 +208,9 @@ fn open_browser_internal(browser: Browser, url: &str) -> Result<Output> {
 /// Open on Linux using the $BROWSER env var
 #[cfg(target_os = "linux")]
 fn open_on_linux_using_browser_env(url: &str) -> Result<Output> {
-    let browsers = ::std::env::var("BROWSER")
-        .map_err(|_| -> Error { Error::new(ErrorKind::NotFound, format!("BROWSER env not set")) })?;
+    let browsers = ::std::env::var("BROWSER").map_err(|_| -> Error {
+        Error::new(ErrorKind::NotFound, format!("BROWSER env not set"))
+    })?;
     for browser in browsers.split(':') {
         // $BROWSER can contain ':' delimited options, each representing a potential browser command line
         if !browser.is_empty() {


### PR DESCRIPTION
In the current implementation on Windows, this crate cannot open a URL which has special characters for `cmd.exe`. (e.g. `http://example.com?q1=0&q2=0`)
This PR fixes the problem by escaping URLs.
