### PR TITLE
Call CoUninitialize, if CoInitializeEx was successful.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,11 +186,11 @@ pub fn open_browser(browser: Browser, url: &str) -> Result<Output> {
 #[cfg(target_os = "windows")]
 #[inline]
 fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> {
+    use winapi::shared::winerror::SUCCEEDED;
     use winapi::um::combaseapi::{CoInitializeEx, CoUninitialize};
     use winapi::um::objbase::{COINIT_APARTMENTTHREADED, COINIT_DISABLE_OLE1DDE};
     use winapi::um::shellapi::ShellExecuteW;
     use winapi::um::winuser::SW_SHOWNORMAL;
-    use winapi::shared::winerror::SUCCEEDED;
     match browser {
         Browser::Default => {
             static OPEN: &[u16] = &['o' as u16, 'p' as u16, 'e' as u16, 'n' as u16, 0x0000];


### PR DESCRIPTION
From https://docs.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-coinitializeex : 

"To close the COM library gracefully on a thread, each successful call to CoInitialize or CoInitializeEx, including any call that returns S_FALSE, must be balanced by a corresponding call to CoUninitialize.".