### PR TITLE
Add support for kioclient and x-www-browser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,7 @@ fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> {
             .or_else(|_| -> Result<ExitStatus> { Command::new("xdg-open").arg(url).status() })
             .or_else(|_| -> Result<ExitStatus> { Command::new("gvfs-open").arg(url).status() })
             .or_else(|_| -> Result<ExitStatus> { Command::new("gnome-open").arg(url).status() })
+            .or_else(|_| -> Result<ExitStatus> { Command::new("kioclient").arg("exec").arg(url).status() })
             .or_else(|_| -> Result<ExitStatus> { Command::new("x-www-browser").arg(url).status() }),
         _ => Err(Error::new(
             ErrorKind::NotFound,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,8 @@ fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> {
         Browser::Default => open_on_unix_using_browser_env(url)
             .or_else(|_| -> Result<ExitStatus> { Command::new("xdg-open").arg(url).status() })
             .or_else(|_| -> Result<ExitStatus> { Command::new("gvfs-open").arg(url).status() })
-            .or_else(|_| -> Result<ExitStatus> { Command::new("gnome-open").arg(url).status() }),
+            .or_else(|_| -> Result<ExitStatus> { Command::new("gnome-open").arg(url).status() })
+            .or_else(|_| -> Result<ExitStatus> { Command::new("x-www-browser").arg(url).status() }),
         _ => Err(Error::new(
             ErrorKind::NotFound,
             "Only the default browser is supported on this platform right now",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,13 +273,16 @@ fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> {
             .or_else(|r| -> Result<ExitStatus> {
                 if let Ok(desktop) = ::std::env::var("XDG_CURRENT_DESKTOP") {
                     if desktop == "KDE" {
-                        return Command::new("kioclient").arg("exec").arg(url).status()
+                        return Command::new("kioclient").arg("exec").arg(url).status();
                     }
                 }
-                Err(r)  // If either `if` check fails, fall through to the next or_else
-            }).or_else(|_| -> Result<ExitStatus> { Command::new("gvfs-open").arg(url).status() })
+                Err(r) // If either `if` check fails, fall through to the next or_else
+            })
+            .or_else(|_| -> Result<ExitStatus> { Command::new("gvfs-open").arg(url).status() })
             .or_else(|_| -> Result<ExitStatus> { Command::new("gnome-open").arg(url).status() })
-            .or_else(|_| -> Result<ExitStatus> { Command::new("kioclient").arg("exec").arg(url).status() })
+            .or_else(|_| -> Result<ExitStatus> {
+                Command::new("kioclient").arg("exec").arg(url).status()
+            })
             .or_else(|_| -> Result<ExitStatus> { Command::new("x-www-browser").arg(url).status() }),
         _ => Err(Error::new(
             ErrorKind::NotFound,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,12 @@ fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> {
             .or_else(|_| -> Result<ExitStatus> {
                 Command::new("kioclient").arg("exec").arg(url).status()
             })
-            .or_else(|_| -> Result<ExitStatus> { Command::new("x-www-browser").arg(url).status() }),
+            .or_else(|e| -> Result<ExitStatus> {
+                if let Ok(_child) = Command::new("x-www-browser").arg(url).spawn() {
+                    return Ok(ExitStatusExt::from_raw(0));
+                }
+                Err(e)
+            }),
         _ => Err(Error::new(
             ErrorKind::NotFound,
             "Only the default browser is supported on this platform right now",


### PR DESCRIPTION
An implementation of the changes discussed in issue #16

I tried to preserve the existing code structure as much as possible in the face of needing to check `std::env` for whether `kioclient` or `gvfs-open` and `gnome-open` should take precedence.

I did some quick checks on my end by unsetting `BROWSER`, and/or commenting out the other entries and everything appears to be working.

For a more robust means of integration testing, one approach I've used before is to mock the commands as follows:
1. Create folders containing mock commands that log success to file (eg. shell scripts with lines like `echo "SUCCESS: $0" > result.log` and equivalent batch files)
2. Run `cargo test --no-run`
3. Run the `./target/debug/webbrowser-*` binary manually, with `PATH` set to contain only the folder full of whichever set of mocks that particular test requires.
4. Tests can now be written which reliably detect both failure due to missing commands and which specific command resulted in success.