### PR TITLE
Feature/add suppress output flag with docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
 Cargo.lock
+
+.idea/
+*.iml

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ pub fn open_browser(browser: Browser, url: &str) -> Result<Output> {
 pub struct BrowserOptions {
     pub browser: Option<Browser>,
     pub suppress_output: Option<bool>,
-    url: String
+    pub url: String
 }
 
 pub fn open_browser_with_options(options: BrowserOptions) -> Result<Output> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,12 @@ impl FromStr for Browser {
     }
 }
 
+pub struct BrowserOptions {
+    pub browser: Option<Browser>,
+    pub suppress_output: Option<bool>,
+    pub url: String,
+}
+
 /// Opens the URL on the default browser of this platform
 ///
 /// Returns Ok(..) so long as the browser invocation was successful. An Err(..) is returned only if
@@ -165,12 +171,35 @@ pub fn open_browser(browser: Browser, url: &str) -> Result<Output> {
     })
 }
 
-pub struct BrowserOptions {
-    pub browser: Option<Browser>,
-    pub suppress_output: Option<bool>,
-    pub url: String
+impl BrowserOptions {
+    pub fn create(url: &str) -> BrowserOptions {
+        BrowserOptions {
+            browser: None,
+            suppress_output: None,
+            url: url.into()
+        }
+    }
+
+    pub fn create_with_suppressed_output(url: &str) -> BrowserOptions {
+        BrowserOptions {
+            browser: None,
+            suppress_output: Some(true),
+            url: url.into()
+        }
+    }
 }
 
+/// Opens the specified URL on the specific browser (if available) requested. Return semantics are
+/// the same as for [open](fn.open.html).
+///
+/// # Examples
+/// ```no_run
+/// use webbrowser::{open_browser_with_options, BrowserOptions};
+///
+/// if open_browser_with_options(BrowserOptions::create("http://github.com")).is_ok() {
+///     // ...
+/// }
+/// ```
 pub fn open_browser_with_options(options: BrowserOptions) -> Result<Output> {
     open_browser_internal(
         options.browser.unwrap_or(Browser::default()),
@@ -372,6 +401,11 @@ compile_error!("Only Windows, Mac OS, Linux and *BSD are currently supported");
 fn test_open_default() {
     assert!(open("http://github.com").is_ok());
     assert!(open("http://github.com?dummy_query1=0&dummy_query2=ｎｏｎａｓｃｉｉ").is_ok());
+}
+
+#[test]
+fn test_open_with_options() {
+    assert!(open_browser_with_options(BrowserOptions::create("http://github.com")).is_ok());
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ pub fn open_browser_with_options(options: BrowserOptions) -> Result<Output> {
 /// fucntion.
 #[cfg(target_os = "windows")]
 #[inline]
-fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> {
+fn open_browser_internal(browser: Browser, url: &str, _: bool) -> Result<ExitStatus> {
     use winapi::shared::winerror::SUCCEEDED;
     use winapi::um::combaseapi::{CoInitializeEx, CoUninitialize};
     use winapi::um::objbase::{COINIT_APARTMENTTHREADED, COINIT_DISABLE_OLE1DDE};
@@ -276,7 +276,7 @@ fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> {
 /// Deal with opening of browsers on Mac OS X, using `open` command
 #[cfg(target_os = "macos")]
 #[inline]
-fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> {
+fn open_browser_internal(browser: Browser, url: &str, _: bool) -> Result<ExitStatus> {
     let mut cmd = Command::new("open");
     match browser {
         Browser::Default => cmd.arg(url).status(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,6 +299,12 @@ fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> {
     }
 }
 
+#[cfg(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 fn adapt_command(cmd: &mut Command, suppress_output: bool) -> &mut Command {
     if suppress_output {
         cmd.stdout(Stdio::null()).stderr(Stdio::null());


### PR DESCRIPTION
This is my attempt to fix [this issue](https://github.com/amodm/webbrowser-rs/issues/20).

I basically added a BrowserOptions struct, that contains a suppress_output flag.

I am fairly new to rust, so I might have wrote some non-rusty code, so feedback is welcome.

