### PR TITLE
Make open_browser take AsRef<OsStr>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["webbrowser", "browser"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 
+[target.'cfg(unix)'.dependencies]
+bstr = "0.2"
+
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.36"
 features = [

--- a/src/android.rs
+++ b/src/android.rs
@@ -1,10 +1,11 @@
 use crate::{Browser, Error, ErrorKind, Result};
+use std::ffi::OsStr;
 pub use std::os::unix::process::ExitStatusExt;
 use std::process::{Command, ExitStatus};
 
 /// Deal with opening of browsers on Android
 #[inline]
-pub fn open_browser_internal(_: Browser, url: &str) -> Result<ExitStatus> {
+pub fn open_browser_internal<P: AsRef<OsStr>>(_: Browser, url: P) -> Result<ExitStatus> {
     Command::new("am")
         .arg("start")
         .arg("--user")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ mod unix;
 use unix::*;
 
 use std::default::Default;
+use std::ffi::OsStr;
 use std::io::{Error, ErrorKind, Result};
 use std::process::{ExitStatus, Output};
 use std::str::FromStr;
@@ -166,7 +167,7 @@ impl FromStr for Browser {
 /// }
 /// ```
 #[cfg(not(target_arch = "wasm32"))]
-pub fn open(url: &str) -> Result<Output> {
+pub fn open<P: AsRef<OsStr>>(url: P) -> Result<Output> {
     open_browser(Browser::Default, url)
 }
 
@@ -197,7 +198,7 @@ pub fn open(url: &str) -> Result<()> {
 /// }
 /// ```
 #[cfg(not(target_arch = "wasm32"))]
-pub fn open_browser(browser: Browser, url: &str) -> Result<Output> {
+pub fn open_browser<P: AsRef<OsStr>>(browser: Browser, url: P) -> Result<Output> {
     open_browser_internal(browser, url).and_then(|status| {
         if let Some(code) = status.code() {
             if code == 0 {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,10 +1,11 @@
 use crate::{Browser, Error, ErrorKind, Result};
+use std::ffi::OsStr;
 pub use std::os::unix::process::ExitStatusExt;
 use std::process::{Command, ExitStatus};
 
 /// Deal with opening of browsers on Mac OS X, using `open` command
 #[inline]
-pub fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> {
+pub fn open_browser_internal<P: AsRef<OsStr>>(browser: Browser, url: P) -> Result<ExitStatus> {
     let mut cmd = Command::new("open");
     match browser {
         Browser::Default => cmd.arg(url).status(),

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -2,6 +2,7 @@ extern crate widestring;
 extern crate winapi;
 
 use crate::{Browser, Error, ErrorKind, Result};
+use std::ffi::OsStr;
 pub use std::os::windows::process::ExitStatusExt;
 use std::process::ExitStatus;
 use std::ptr;
@@ -11,7 +12,7 @@ use widestring::U16CString;
 /// https://docs.microsoft.com/en-us/windows/desktop/api/shellapi/nf-shellapi-shellexecutew)
 /// fucntion.
 #[inline]
-pub fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> {
+pub fn open_browser_internal<P: AsRef<OsStr>>(browser: Browser, url: P) -> Result<ExitStatus> {
     use winapi::shared::winerror::SUCCEEDED;
     use winapi::um::combaseapi::{CoInitializeEx, CoUninitialize};
     use winapi::um::objbase::{COINIT_APARTMENTTHREADED, COINIT_DISABLE_OLE1DDE};
@@ -21,7 +22,7 @@ pub fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> 
         Browser::Default => {
             static OPEN: &[u16] = &['o' as u16, 'p' as u16, 'e' as u16, 'n' as u16, 0x0000];
             let url =
-                U16CString::from_str(url).map_err(|e| Error::new(ErrorKind::InvalidInput, e))?;
+                U16CString::from_os_str(url).map_err(|e| Error::new(ErrorKind::InvalidInput, e))?;
             let code = unsafe {
                 let coinitializeex_result = CoInitializeEx(
                     ptr::null_mut(),


### PR DESCRIPTION
I wanted to use this to open files in the web browser, but as it turns out, it only accepts strings. I was quite surprised to see this, so I added code to allow using anything implementing AsRef<OsStr> instead, which should support both url and filepath usecases.

I have tested this on Unix and it works perfectly. I'd also like to add support for the major browsers on Windows/Unix, as I believe it should be as simple as doing "firefox path" or "chrome path"