### PR TITLE
Use JNI instead of shell on android.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ features = [
 winapi = { version = "0.3.6", features = ["combaseapi", "objbase", "shellapi", "winerror"] }
 widestring = "0.4.0"
 
+[target.'cfg(target_os = "android")'.dependencies]
+jni = "0.19"
+ndk-glue = { version = "0.4" }
+
 [dev-dependencies]
 actix-web = "2.0"
 actix-rt = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ widestring = "0.4.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.19"
-ndk-glue = { version = "0.4" }
+ndk-glue = { version = ">= 0.3, <= 0.6" }
 
 [dev-dependencies]
 actix-web = "2.0"

--- a/src/android.rs
+++ b/src/android.rs
@@ -1,17 +1,65 @@
 use crate::{Browser, Error, ErrorKind, Result};
+use jni::objects::JValue;
 pub use std::os::unix::process::ExitStatusExt;
 use std::process::{Command, ExitStatus};
 
 /// Deal with opening of browsers on Android
 #[inline]
 pub fn open_browser_internal(_: Browser, url: &str) -> Result<ExitStatus> {
-    Command::new("am")
-        .arg("start")
-        .arg("--user")
-        .arg("0")
-        .arg("-a")
-        .arg("android.intent.action.VIEW")
-        .arg("-d")
-        .arg(url)
-        .status()
+    // Create a VM for executing Java calls
+    let native_activity = ndk_glue::native_activity();
+    let vm_ptr = native_activity.vm();
+    let vm = unsafe { jni::JavaVM::from_raw(vm_ptr) }.unwrap();
+    let env = vm.attach_current_thread().map_err(|_| -> Error {
+        Error::new(ErrorKind::Other, "Failed to attach current thread")
+    })?;
+
+    // Create ACTION_VIEW object
+    let intent_class = env
+        .find_class("android/content/Intent")
+        .map_err(|_| -> Error { Error::new(ErrorKind::NotFound, "Failed to find Intent class") })?;
+    let action_view = env
+        .get_static_field(intent_class, "ACTION_VIEW", "Ljava/lang/String;")
+        .map_err(|_| -> Error {
+            Error::new(ErrorKind::NotFound, "Failed to get intent.ACTION_VIEW")
+        })?;
+
+    // Create Uri object
+    let uri_class = env
+        .find_class("android/net/Uri")
+        .map_err(|_| -> Error { Error::new(ErrorKind::NotFound, "Failed to find Uri class") })?;
+    let url = env
+        .new_string(url)
+        .map_err(|_| -> Error { Error::new(ErrorKind::Other, "Failed to create JNI string") })?;
+    let uri = env
+        .call_static_method(
+            uri_class,
+            "parse",
+            "(Ljava/lang/String;)Landroid/net/Uri;",
+            &[JValue::Object(*url)],
+        )
+        .map_err(|_| -> Error { Error::new(ErrorKind::Other, "Failed to parse JNI Uri") })?;
+
+    // Create new ACTION_VIEW intent with the uri
+    let intent = env
+        .alloc_object(intent_class)
+        .map_err(|_| -> Error { Error::new(ErrorKind::Other, "Failed to allocate intent") })?;
+    env.call_method(
+        intent,
+        "<init>",
+        "(Ljava/lang/String;Landroid/net/Uri;)V",
+        &[action_view, uri],
+    )
+    .map_err(|_| -> Error { Error::new(ErrorKind::Other, "Failed to initialize intent") })?;
+
+    // Start the intent activity.
+    env.call_method(
+        native_activity.activity(),
+        "startActivity",
+        "(Landroid/content/Intent;)V",
+        &[JValue::Object(intent)],
+    )
+    .map_err(|_| -> Error { Error::new(ErrorKind::Other, "Failed to start activity") })?;
+
+    Ok(ExitStatus::from_raw(0))
 }


### PR DESCRIPTION
Using shell and calling `am start ...` isn't allowed on newer android versions as far as i can tell. I think JNI should be used to start the activity instead.