### PR TITLE
Delete  Irrelevant open command for unix

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -23,7 +23,6 @@ pub fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> 
             })
             .or_else(|_| -> Result<ExitStatus> { Command::new("gvfs-open").arg(url).status() })
             .or_else(|_| -> Result<ExitStatus> { Command::new("gnome-open").arg(url).status() })
-            .or_else(|_| -> Result<ExitStatus> { Command::new("open").arg(url).status() })
             .or_else(|_| -> Result<ExitStatus> {
                 Command::new("kioclient").arg("exec").arg(url).status()
             })


### PR DESCRIPTION
`open` command works to handle browser for only MacOS.
For Unix, it cause the followings error:

```
$ cargo test
...
running 1 test
Couldn't get a file descriptor referring to the console
test tests::test_open_default ... FAILED

failures:

---- tests::test_open_default stdout ----
thread 'tests::test_open_default' panicked at 'failed to open browser: Custom { kind: Other, error: "return code 1" }', tests/common.rs:61:36
```

I found this error in WSL2 environments (no `xdg-open`, `gvfs-open`, `gnome-open` but `x-www-browser` is only available).
As a discussed [here](https://unix.stackexchange.com/questions/253376/open-command-to-open-a-file-in-an-application), `open` command in Unix is link to `openvt` command, which is not to open browser.
This cause panic and the process finish  before calling `x-www-browser`.

This PR fix above problem and works fine by calling `x-www-browser`.
