### PR TITLE
Change signature of pub fns to return Result<()> instead of Result<Output>. Fixes #42

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        rust: [stable, beta, nightly]
+        rust: [stable]
     continue-on-error: ${{ matrix.rust != 'stable' }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta, nightly]
+        rust: [stable]
     continue-on-error: ${{ matrix.rust != 'stable' }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        rust: [stable, beta, nightly]
+        rust: [stable, beta]
     continue-on-error: ${{ matrix.rust != 'stable' }}
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ features = [
   'Window'
 ]
 
+[features]
+wasm-console = ["web-sys/console"]
+
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.6", features = ["combaseapi", "objbase", "shellapi", "winerror"] }
 widestring = "0.4.0"

--- a/src/android.rs
+++ b/src/android.rs
@@ -5,7 +5,7 @@ use std::process::ExitStatus;
 
 /// Deal with opening of browsers on Android
 #[inline]
-pub fn open_browser_internal(_: Browser, url: &str) -> Result<ExitStatus> {
+pub fn open_browser_internal(_: Browser, url: &str) -> Result<()> {
     // Create a VM for executing Java calls
     let native_activity = ndk_glue::native_activity();
     let vm_ptr = native_activity.vm();
@@ -61,5 +61,5 @@ pub fn open_browser_internal(_: Browser, url: &str) -> Result<ExitStatus> {
     )
     .map_err(|_| -> Error { Error::new(ErrorKind::Other, "Failed to start activity") })?;
 
-    Ok(ExitStatus::from_raw(0))
+    Ok(())
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,24 @@
+use crate::{Error, ErrorKind, Result};
+use std::process::ExitStatus;
+
+/// Analyses return code from a command ExitStatus to create the right
+/// Result<()>
+pub fn from_status(res: Result<ExitStatus>) -> Result<()> {
+    match res {
+        Ok(status) => {
+            if let Some(code) = status.code() {
+                if code == 0 {
+                    Ok(())
+                } else {
+                    Err(Error::new(
+                        ErrorKind::Other,
+                        format!("return code {}", code),
+                    ))
+                }
+            } else {
+                Err(Error::new(ErrorKind::Other, "interrupted by signal"))
+            }
+        }
+        Err(err) => Err(err),
+    }
+}

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,13 +1,15 @@
 use crate::{Browser, Error, ErrorKind, Result};
-pub use std::os::unix::process::ExitStatusExt;
-use std::process::{Command, ExitStatus};
+use std::process::Command;
+
+mod common;
+use common::from_status;
 
 /// Deal with opening of browsers on Mac OS X, using `open` command
 #[inline]
-pub fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> {
+pub fn open_browser_internal(browser: Browser, url: &str) -> Result<()> {
     let mut cmd = Command::new("open");
     match browser {
-        Browser::Default => cmd.arg(url).status(),
+        Browser::Default => from_status(cmd.arg(url).status()),
         _ => {
             let app: Option<&str> = match browser {
                 Browser::Firefox => Some("Firefox"),
@@ -18,7 +20,7 @@ pub fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> 
                 _ => None,
             };
             match app {
-                Some(name) => cmd.arg("-a").arg(name).arg(url).status(),
+                Some(name) => from_status(cmd.arg("-a").arg(name).arg(url).status()),
                 None => Err(Error::new(
                     ErrorKind::NotFound,
                     format!("Unsupported browser {:?}", browser),

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,6 +1,9 @@
 use crate::{Browser, Error, ErrorKind, Result};
-pub use std::os::unix::process::ExitStatusExt;
+use std::os::unix::process::ExitStatusExt;
 use std::process::{Command, ExitStatus};
+
+mod common;
+use common::from_status;
 
 /// Deal with opening of browsers on Linux and *BSD - currently supports only the default browser
 ///
@@ -9,7 +12,11 @@ use std::process::{Command, ExitStatus};
 /// 2. Attempt to open the url via xdg-open, gvfs-open, gnome-open, open, respectively, whichever works
 ///    first
 #[inline]
-pub fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> {
+pub fn open_browser_internal(browser: Browser, url: &str) -> Result<()> {
+    from_status(open_browser_unix(browser, url))
+}
+
+fn open_browser_unix(browser: Browser, url: &str) -> Result<ExitStatus> {
     match browser {
         Browser::Default => open_on_unix_using_browser_env(url)
             .or_else(|_| -> Result<ExitStatus> { Command::new("xdg-open").arg(url).status() })

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,42 @@
+use crate::{Browser, ErrorKind, Result};
+
+/// Deal with opening a URL in wasm32. This implementation ignores the browser attribute
+/// and always opens URLs in the same browser where wasm32 vm is running.
+#[inline]
+pub fn open_browser_internal(_: Browser, url: &str) -> Result<()> {
+    // we can override the target by the env var WEBBROWSER_WASM_TARGET at compile time
+    let configured_target = option_env!("WEBBROWSER_WASM_TARGET");
+    let window = web_sys::window();
+    match window {
+        Some(w) => {
+            let target = configured_target.unwrap_or_else(|| "_blank");
+            wasm_console_log(&format!("target for url {} detected as {}", url, target));
+
+            match w.open_with_url_and_target(url, target) {
+                Ok(x) => match x {
+                    Some(y) => Ok(()),
+                    None => {
+                        const err_msg: &'static str =
+                            "popup blocked? window detected, but open_url failed";
+                        wasm_console_log(&err_msg);
+                        Err(std::io::Error::new(ErrorKind::Other, err_msg))
+                    }
+                },
+                Err(_) => {
+                    wasm_console_log("window error while opening url");
+                    Err(std::io::Error::new(ErrorKind::Other, "error opening url"))
+                }
+            }
+        }
+        None => Err(std::io::Error::new(
+            ErrorKind::Other,
+            "should have a window in this context",
+        )),
+    }
+}
+
+/// Print to browser console
+fn wasm_console_log(msg: &str) {
+    #[cfg(debug_assertions)]
+    web_sys::console::log_1(&format!("[webbrowser] {}", &msg).into());
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -3,7 +3,6 @@ extern crate winapi;
 
 use crate::{Browser, Error, ErrorKind, Result};
 pub use std::os::windows::process::ExitStatusExt;
-use std::process::ExitStatus;
 use std::ptr;
 use widestring::U16CString;
 
@@ -11,7 +10,7 @@ use widestring::U16CString;
 /// https://docs.microsoft.com/en-us/windows/desktop/api/shellapi/nf-shellapi-shellexecutew)
 /// fucntion.
 #[inline]
-pub fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> {
+pub fn open_browser_internal(browser: Browser, url: &str) -> Result<()> {
     use winapi::shared::winerror::SUCCEEDED;
     use winapi::um::combaseapi::{CoInitializeEx, CoUninitialize};
     use winapi::um::objbase::{COINIT_APARTMENTTHREADED, COINIT_DISABLE_OLE1DDE};
@@ -41,7 +40,7 @@ pub fn open_browser_internal(browser: Browser, url: &str) -> Result<ExitStatus> 
                 code
             };
             if code > 32 {
-                Ok(ExitStatus::from_raw(0))
+                Ok(())
             } else {
                 Err(Error::last_os_error())
             }


### PR DESCRIPTION
Rationale explained in #42.

This PR changes the return type of the two public functions:
* `fn open(url: &str) -> Result<Output>`, and
* `fn open_browser(browser: Browser, url: &str) -> Result<Output>`

from `Result<Output>` to `Result<()>`, as actionability is technically possible only on the `Error`.

As almost all users of this library are just doing a `is_ok()` or equivalent check on the `Result`, without destructuring the `Ok(output)` part, so this change should be non-breaking for almost everyone.