### PR TITLE
Introduce Browser::is_available() to fix #46

### DIFF
--- a/src/android.rs
+++ b/src/android.rs
@@ -3,9 +3,27 @@ use jni::objects::JValue;
 pub use std::os::unix::process::ExitStatusExt;
 use std::process::ExitStatus;
 
-/// Deal with opening of browsers on Android. BrowserOptions are ignored here.
+/// Deal with opening of browsers on Android. Only [Browser::Default] is supported, and
+/// in options, only [BrowserOptions::dry_run] is honoured.
 #[inline]
-pub fn open_browser_internal(_: Browser, url: &str, _: &BrowserOptions) -> Result<()> {
+pub fn open_browser_internal(browser: Browser, url: &str, options: &BrowserOptions) -> Result<()> {
+    match browser {
+        Browser::Default => open_browser_default(url, options),
+        _ => Err(Error::new(
+            ErrorKind::NotFound,
+            "only default browser supported",
+        )),
+    }
+}
+
+/// Open the default browser
+#[inline]
+pub fn open_browser_default(url: &str, options: &BrowserOptions) -> Result<()> {
+    // always return true for a dry run
+    if options.dry_run {
+        return Ok(());
+    }
+
     // Create a VM for executing Java calls
     let native_activity = ndk_glue::native_activity();
     let vm_ptr = native_activity.vm();

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -4,6 +4,11 @@ use crate::{Browser, BrowserOptions, Error, ErrorKind, Result};
 /// and always opens URLs in the same browser where wasm32 vm is running.
 #[inline]
 pub fn open_browser_internal(_: Browser, url: &str, options: &BrowserOptions) -> Result<()> {
+    // always return true for a dry run
+    if options.dry_run {
+        return Ok(());
+    }
+
     let window = web_sys::window();
     match window {
         Some(w) => match w.open_with_url_and_target(url, &options.target_hint) {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -10,9 +10,9 @@ use widestring::U16CString;
 /// https://docs.microsoft.com/en-us/windows/desktop/api/shellapi/nf-shellapi-shellexecutew)
 /// function.
 ///
-/// We ignore BrowserOptions on Windows.
+/// We ignore BrowserOptions on Windows, except for honouring [BrowserOptions::dry_run]
 #[inline]
-pub fn open_browser_internal(browser: Browser, url: &str, _: &BrowserOptions) -> Result<()> {
+pub fn open_browser_internal(browser: Browser, url: &str, options: &BrowserOptions) -> Result<()> {
     use winapi::shared::winerror::SUCCEEDED;
     use winapi::um::combaseapi::{CoInitializeEx, CoUninitialize};
     use winapi::um::objbase::{COINIT_APARTMENTTHREADED, COINIT_DISABLE_OLE1DDE};
@@ -20,6 +20,11 @@ pub fn open_browser_internal(browser: Browser, url: &str, _: &BrowserOptions) ->
     use winapi::um::winuser::SW_SHOWNORMAL;
     match browser {
         Browser::Default => {
+            // always return true for a dry run for default browser
+            if options.dry_run {
+                return Ok(());
+            }
+
             static OPEN: &[u16] = &['o' as u16, 'p' as u16, 'e' as u16, 'n' as u16, 0x0000];
             let url =
                 U16CString::from_str(url).map_err(|e| Error::new(ErrorKind::InvalidInput, e))?;

--- a/tests/test_android.rs
+++ b/tests/test_android.rs
@@ -9,6 +9,7 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
     use std::process::Command;
+    use webbrowser::Browser;
 
     // to run this test, run it as:
     // cargo test --test test_android -- --ignored
@@ -73,5 +74,15 @@ mod tests {
             .next()
             .expect("no ip address found")
             .into()
+    }
+
+    #[test]
+    fn test_existence_default() {
+        assert!(Browser::is_available(), "should have found a browser");
+    }
+
+    #[test]
+    fn test_non_existence_safari() {
+        assert!(!Browser::Safari.exists(), "should not have found Safari");
     }
 }

--- a/tests/test_macos.rs
+++ b/tests/test_macos.rs
@@ -29,4 +29,22 @@ mod tests {
     async fn test_open_chrome() {
         check_browser(Browser::Chrome, TEST_PLATFORM).await;
     }
+
+    #[test]
+    fn test_existence_default() {
+        assert!(Browser::is_available(), "should have found a browser");
+    }
+
+    #[test]
+    fn test_existence_safari() {
+        assert!(Browser::Safari.exists(), "should have found Safari");
+    }
+
+    #[test]
+    fn test_non_existence_webpositive() {
+        assert!(
+            !Browser::WebPositive.exists(),
+            "should not have found WebPositive",
+        );
+    }
 }

--- a/tests/test_unix.rs
+++ b/tests/test_unix.rs
@@ -12,4 +12,14 @@ mod tests {
     async fn test_open_default() {
         check_browser(Browser::Default, TEST_PLATFORM).await;
     }
+
+    #[test]
+    fn test_existence_default() {
+        assert!(Browser::is_available(), "should have found a browser");
+    }
+
+    #[test]
+    fn test_non_existence_safari() {
+        assert!(!Browser::Safari.exists(), "should not have found Safari");
+    }
 }

--- a/tests/test_wasm.rs
+++ b/tests/test_wasm.rs
@@ -8,6 +8,7 @@ mod tests {
     use super::common::check_request_received_using;
     use std::fs;
     use std::path::PathBuf;
+    use webbrowser::Browser;
 
     // to run this test, run it as:
     // cargo test --test test_wasm32 -- --ignored
@@ -43,5 +44,15 @@ mod tests {
             status.expect("browser open failed");
         })
         .await;
+    }
+
+    #[test]
+    fn test_existence_default() {
+        assert!(Browser::is_available(), "should've found a browser");
+    }
+
+    #[test]
+    fn test_non_existence_safari() {
+        assert!(!Browser::Safari.exists(), "should've not found Safari");
     }
 }

--- a/tests/test_windows.rs
+++ b/tests/test_windows.rs
@@ -18,4 +18,14 @@ mod tests {
     async fn test_open_internet_explorer() {
         check_browser(Browser::InternetExplorer, TEST_PLATFORM).await;
     }
+
+    #[test]
+    fn test_existence_default() {
+        assert!(Browser::is_available(), "should have found a browser");
+    }
+
+    #[test]
+    fn test_non_existence_safari() {
+        assert!(!Browser::Safari.exists(), "should not have found Safari");
+    }
 }


### PR DESCRIPTION
Introduced the following methods to check for validity of browser, if required, without opening a url:
* `Browser::is_available()`
* `Browser::<name>::exists()`

`Browser::is_available()` just calls `Browser::Default::exists()`, which then invokes an `open_browser_with_options()` call using `BrowserOptions::new().with_dry_run()`, which is a new option being introduced with this commit.

Fixes #46.