### PR TITLE
When using XDG, force browser to open, ignoring local app associations

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  RUST_LOG: webbrowser=TRACE
   CARGO_APK_VERSION: '0.8.2'
 
 jobs:

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -15,6 +15,7 @@ jobs:
   build:
     name: Build
     runs-on: macos-latest
+    if: ${{ !contains(github.event.head_commit.message, '#build-') || contains(github.event.head_commit.message, '#build-android') }}
     strategy:
       matrix:
         rust: [stable ]

--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  RUST_LOG: webbrowser=TRACE
 
 jobs:
   build:

--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -14,6 +14,7 @@ jobs:
   build:
     name: Build
     runs-on: macos-latest
+    if: ${{ !contains(github.event.head_commit.message, '#build-') || contains(github.event.head_commit.message, '#build-ios') }}
     strategy:
       matrix:
         rust: [stable]

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  RUST_LOG: webbrowser=TRACE
 
 jobs:
   build:

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -15,6 +15,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '#build-') || contains(github.event.head_commit.message, '#build-linux') }}
     strategy:
       max-parallel: 1
       matrix:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -14,6 +14,7 @@ jobs:
   build:
     name: Build
     runs-on: macos-latest
+    if: ${{ !contains(github.event.head_commit.message, '#build-') || contains(github.event.head_commit.message, '#build-macos') }}
     strategy:
       matrix:
         rust: [stable]

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  RUST_LOG: webbrowser=TRACE
 
 jobs:
   build:

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -15,6 +15,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '#build-') || contains(github.event.head_commit.message, '#build-wasm') }}
     strategy:
       matrix:
         rust: [stable]

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  RUST_LOG: webbrowser=TRACE
   WASM_PACK_VERSION: '0.10.2'
 
 jobs:

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -62,7 +62,8 @@ jobs:
           firefox-version: '97.0'
       - name: Custom headless firefox script
         run: |
-          echo 'nohup firefox --headless "$*" >/dev/null 2>&1 &' > /tmp/hffox
+          echo '#!/bin/sh' > /tmp/hffox
+          echo 'nohup firefox --headless "$*" >/dev/null 2>&1 &' >> /tmp/hffox
           chmod 755 /tmp/hffox
 
       # Run tests

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -14,6 +14,7 @@ jobs:
   build:
     name: Build
     runs-on: windows-latest
+    if: ${{ !contains(github.event.head_commit.message, '#build-') || contains(github.event.head_commit.message, '#build-windows') }}
     strategy:
       max-parallel: 1
       matrix:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  RUST_LOG: webbrowser=TRACE
 
 jobs:
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
+log = "0.4"
 url = "2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
@@ -22,6 +23,9 @@ features = [
 
 [features]
 wasm-console = ["web-sys/console"]
+
+[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "haiku"))'.dependencies]
+dirs = "4.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["combaseapi", "impl-default", "objbase", "shellapi", "winerror"] }
@@ -39,6 +43,7 @@ objc = "0.2.7"
 actix-web = "4"
 actix-files = "0.6"
 crossbeam-channel = "0.5"
+env_logger = "0.9.0"
 tokio = { version = "1", features = ["full"] }
 urlencoding = "2.1"
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -388,6 +388,108 @@ static TEXT_BROWSERS: [&str; 9] = [
 ];
 
 #[cfg(test)]
-pub mod tests_xdg {
-    pub use super::*;
+mod tests_xdg {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+
+    fn get_temp_path(name: &str, suffix: &str) -> String {
+        let pid = std::process::id();
+        std::env::temp_dir()
+            .join(format!("{}.{}.{}", name, pid, suffix))
+            .into_os_string()
+            .into_string()
+            .expect("failed to convert into string")
+    }
+
+    #[test]
+    fn test_xdg_open_local_file() {
+        let _ = env_logger::try_init();
+
+        // ensure flag file is not existing
+        let flag_path = get_temp_path("test_xdg", "flag");
+        let _ = std::fs::remove_file(&flag_path);
+
+        // create browser script
+        let txt_path = get_temp_path("test_xdf", "txt");
+        let browser_path = get_temp_path("test_xdg", "browser");
+        {
+            let mut browser_file =
+                File::create(&browser_path).expect("failed to create browser file");
+            let _ = browser_file.write_fmt(format_args!(
+                r#"#!/bin/bash
+                if [ "$1" != "p1" ]; then
+                    echo "1st parameter should've been p1" >&2
+                    exit 1
+                elif [ "$2" != "{}" ]; then
+                    echo "2nd parameter should've been {}" >&2
+                    exit 1
+                elif [ "$3" != "p3" ]; then
+                    echo "3rd parameter should've been p3" >&2
+                    exit 1
+                fi
+
+                echo "$2" > "{}"
+            "#,
+                &txt_path, &txt_path, &flag_path
+            ));
+            let mut perms = browser_file
+                .metadata()
+                .expect("failed to get permissions")
+                .permissions();
+            perms.set_mode(0o755);
+            let _ = browser_file.set_permissions(perms);
+        }
+
+        // create xdg desktop config
+        let config_path = get_temp_path("test_xdg", "desktop");
+        {
+            let mut xdg_file =
+                std::fs::File::create(&config_path).expect("failed to create xdg desktop file");
+            let _ = xdg_file.write_fmt(format_args!(
+                r#"# this line should be ignored
+[Desktop Entry]
+Exec={} p1 %u p3
+[Another Entry]
+Exec=/bin/ls
+# the above Exec line should be getting ignored
+            "#,
+                &browser_path
+            ));
+        }
+
+        // now try opening browser using above desktop config
+        let result = open_using_xdg_config(
+            &PathBuf::from(&config_path),
+            &BrowserOptions::default(),
+            &txt_path,
+        );
+
+        // we need to wait until the flag file shows up due to the async
+        // nature of browser invocation
+        for _ in 0..10 {
+            if std::fs::read_to_string(&flag_path).is_ok() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        // validate that the flag file contains the url we passed
+        assert_eq!(
+            std::fs::read_to_string(&flag_path)
+                .expect("flag file not found")
+                .trim(),
+            &txt_path,
+        );
+        assert!(result.is_ok());
+
+        // delete all temp files
+        let _ = std::fs::remove_file(&txt_path);
+        let _ = std::fs::remove_file(&flag_path);
+        let _ = std::fs::remove_file(&browser_path);
+        let _ = std::fs::remove_file(&config_path);
+
+        assert!(result.is_ok());
+    }
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -24,7 +24,6 @@ macro_rules! try_browser {
 /// 2. Attempt to use xdg-open
 /// 3. Attempt to use window manager specific commands, like gnome-open, kde-open etc.
 /// 4. Fallback to x-www-browser
-#[inline]
 pub fn open_browser_internal(browser: Browser, url: &str, options: &BrowserOptions) -> Result<()> {
     match browser {
         Browser::Default => open_browser_default(url, options),
@@ -39,7 +38,6 @@ pub fn open_browser_internal(browser: Browser, url: &str, options: &BrowserOptio
 ///
 /// [BrowserOptions::dry_run] is handled inside [run_command], as all execution paths eventually
 /// rely on it to execute.
-#[inline]
 fn open_browser_default(url: &str, options: &BrowserOptions) -> Result<()> {
     // we first try with the $BROWSER env
     try_with_browser_env(url, options)
@@ -80,7 +78,6 @@ fn open_browser_default(url: &str, options: &BrowserOptions) -> Result<()> {
         .map(|_| ())
 }
 
-#[inline]
 fn try_with_browser_env(url: &str, options: &BrowserOptions) -> Result<()> {
     // $BROWSER can contain ':' delimited options, each representing a potential browser command line
     for browser in std::env::var("BROWSER")
@@ -119,7 +116,6 @@ fn try_with_browser_env(url: &str, options: &BrowserOptions) -> Result<()> {
 }
 
 /// Detect the desktop environment
-#[inline]
 fn guess_desktop_env() -> &'static str {
     let unknown = "unknown";
     let xcd: String = std::env::var("XDG_CURRENT_DESKTOP")
@@ -152,7 +148,6 @@ fn guess_desktop_env() -> &'static str {
 
 /// Handle Haiku explicitly, as it uses an "open" command, similar to macos
 /// but on other Unixes, open ends up translating to shell open fd
-#[inline]
 fn try_haiku(options: &BrowserOptions, url: &str) -> Result<()> {
     if cfg!(target_os = "haiku") {
         try_browser!(options, "open", url).map(|_| ())
@@ -163,7 +158,6 @@ fn try_haiku(options: &BrowserOptions, url: &str) -> Result<()> {
 
 /// Dig into XDG settings (if xdg is available) to force it to open the browser, instead of
 /// the default application
-#[inline]
 fn try_xdg(options: &BrowserOptions, url: &str) -> Result<()> {
     // run: xdg-settings get default-web-browser
     let browser_name_os = for_matching_path("xdg-settings", |pb| {
@@ -304,7 +298,6 @@ fn get_xdg_dirs() -> Vec<PathBuf> {
 }
 
 /// Returns true if specified command refers to a known list of text browsers
-#[inline]
 fn is_text_browser(pb: &Path) -> bool {
     for browser in TEXT_BROWSERS.iter() {
         if pb.ends_with(browser) {
@@ -314,7 +307,6 @@ fn is_text_browser(pb: &Path) -> bool {
     false
 }
 
-#[inline]
 fn for_matching_path<F, T>(name: &str, op: F) -> Result<T>
 where
     F: FnOnce(&PathBuf) -> Result<T>,
@@ -351,7 +343,6 @@ where
 }
 
 /// Run the specified command in foreground/background
-#[inline]
 fn run_command(cmd: &mut Command, background: bool, options: &BrowserOptions) -> Result<()> {
     // if dry_run, we return a true, as executable existence check has
     // already been done

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,6 +1,8 @@
 use crate::{Browser, BrowserOptions, Error, ErrorKind, Result};
+use log::{debug, trace};
+use std::io::{BufRead, BufReader};
 use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
+use std::path::{Path, PathBuf, MAIN_SEPARATOR};
 use std::process::{Command, Stdio};
 
 macro_rules! try_browser {
@@ -43,8 +45,8 @@ fn open_browser_default(url: &str, options: &BrowserOptions) -> Result<()> {
     try_with_browser_env(url, options)
         // allow for haiku's open specifically
         .or_else(|_| try_haiku(options, url))
-        // then we try with xdg-open
-        .or_else(|_| try_browser!(options, "xdg-open", url))
+        // then we try with xdg configuration
+        .or_else(|_| try_xdg(options, url))
         // else do desktop specific stuff
         .or_else(|r| match guess_desktop_env() {
             "kde" => try_browser!(options, "kde-open", url)
@@ -148,8 +150,8 @@ fn guess_desktop_env() -> &'static str {
     }
 }
 
-// Handle Haiku explicitly, as it uses an "open" command, similar to macos
-// but on other Unixes, open ends up translating to shell open fd
+/// Handle Haiku explicitly, as it uses an "open" command, similar to macos
+/// but on other Unixes, open ends up translating to shell open fd
 #[inline]
 fn try_haiku(options: &BrowserOptions, url: &str) -> Result<()> {
     if cfg!(target_os = "haiku") {
@@ -157,6 +159,148 @@ fn try_haiku(options: &BrowserOptions, url: &str) -> Result<()> {
     } else {
         Err(Error::new(ErrorKind::NotFound, "Not on haiku"))
     }
+}
+
+/// Dig into XDG settings (if xdg is available) to force it to open the browser, instead of
+/// the default application
+#[inline]
+fn try_xdg(options: &BrowserOptions, url: &str) -> Result<()> {
+    // run: xdg-settings get default-web-browser
+    let browser_name_os = for_matching_path("xdg-settings", |pb| {
+        Command::new(pb)
+            .args(["get", "default-web-browser"])
+            .stdin(Stdio::null())
+            .stderr(Stdio::null())
+            .output()
+    })
+    .map_err(|_| Error::new(ErrorKind::NotFound, "unable to determine xdg browser"))?
+    .stdout;
+
+    // convert browser name to a utf-8 string and trim off the trailing newline
+    let browser_name = String::from_utf8(browser_name_os)
+        .map_err(|_| Error::new(ErrorKind::NotFound, "invalid default browser name"))?
+        .trim()
+        .to_owned();
+    trace!("found xdg browser: {:?}", &browser_name);
+
+    // search for the config file corresponding to this browser name
+    let mut config_found = false;
+    let app_suffix = "applications";
+    for xdg_dir in get_xdg_dirs().iter_mut() {
+        let mut config_path = xdg_dir.join(app_suffix).join(&browser_name);
+        trace!("checking for xdg config at {:?}", config_path);
+        let mut metadata = config_path.metadata();
+        if metadata.is_err() && browser_name.contains('-') {
+            // as per the spec, we need to replace '-' with /
+            let child_path = browser_name.replace('-', "/");
+            config_path = xdg_dir.join(app_suffix).join(child_path);
+            metadata = config_path.metadata();
+        }
+        if metadata.is_ok() {
+            // we've found the config file, so we try running using that
+            config_found = true;
+            match open_using_xdg_config(&config_path, options, url) {
+                Ok(x) => return Ok(x), // return if successful
+                Err(err) => {
+                    // if we got an error other than NotFound, then we short
+                    // circuit, and do not try any more options, else we
+                    // continue to try more
+                    if err.kind() != ErrorKind::NotFound {
+                        return Err(err);
+                    }
+                }
+            }
+        }
+    }
+
+    if config_found {
+        Err(Error::new(ErrorKind::Other, "xdg-open failed"))
+    } else {
+        Err(Error::new(ErrorKind::NotFound, "no valid xdg config found"))
+    }
+}
+
+/// Opens `url` using xdg configuration found in `config_path`
+///
+/// See https://specifications.freedesktop.org/desktop-entry-spec/latest for details
+fn open_using_xdg_config(config_path: &PathBuf, options: &BrowserOptions, url: &str) -> Result<()> {
+    let file = std::fs::File::open(config_path)?;
+    let mut in_desktop_entry = false;
+    let mut hidden = false;
+    let mut cmdline: Option<String> = None;
+    let mut requires_terminal = false;
+
+    // we capture important keys under the [Desktop Entry] section, as defined under:
+    // https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html
+    for line in BufReader::new(file).lines().flatten() {
+        if line == "[Desktop Entry]" {
+            in_desktop_entry = true;
+        } else if line.starts_with('[') {
+            in_desktop_entry = false;
+        } else if in_desktop_entry && !line.starts_with('#') {
+            if let Some(idx) = line.find('=') {
+                let key = &line[..idx];
+                let value = &line[idx + 1..];
+                match key {
+                    "Exec" => cmdline = Some(value.to_owned()),
+                    "Hidden" => hidden = value == "true",
+                    "Terminal" => requires_terminal = value == "true",
+                    _ => (), // ignore
+                }
+            }
+        }
+    }
+
+    if hidden {
+        // we ignore this config if it was marked hidden/deleted
+        return Err(Error::new(ErrorKind::NotFound, "xdg config is hidden"));
+    }
+
+    if let Some(cmdline) = cmdline {
+        // we have a valid configuration
+        let cmdarr: Vec<&str> = cmdline.split_ascii_whitespace().collect();
+        let browser_cmd = cmdarr[0];
+        for_matching_path(browser_cmd, |pb| {
+            let mut cmd = Command::new(pb);
+            let mut url_added = false;
+            for arg in cmdarr.iter().skip(1) {
+                match *arg {
+                    "%u" | "%U" | "%f" | "%F" => {
+                        url_added = true;
+                        cmd.arg(url)
+                    }
+                    _ => cmd.arg(arg),
+                };
+            }
+            if !url_added {
+                // append the url as an argument only if it was not already set
+                cmd.arg(url);
+            }
+            run_command(&mut cmd, !requires_terminal, options)
+        })
+    } else {
+        // we don't have a valid config
+        Err(Error::new(ErrorKind::NotFound, "not a valid xdg config"))
+    }
+}
+
+/// Get the list of directories in which the desktop file needs to be searched
+fn get_xdg_dirs() -> Vec<PathBuf> {
+    let mut xdg_dirs: Vec<PathBuf> = Vec::new();
+
+    if let Some(user_dir) = dirs::data_dir() {
+        xdg_dirs.push(user_dir);
+    }
+    if let Ok(data_dirs) = std::env::var("XDG_DATA_DIRS") {
+        for d in data_dirs.split(':') {
+            xdg_dirs.push(PathBuf::from(d));
+        }
+    } else {
+        xdg_dirs.push(PathBuf::from("/usr/local/share"));
+        xdg_dirs.push(PathBuf::from("/usr/share"));
+    }
+
+    xdg_dirs
 }
 
 /// Returns true if specified command refers to a known list of text browsers
@@ -171,15 +315,15 @@ fn is_text_browser(pb: &Path) -> bool {
 }
 
 #[inline]
-fn for_matching_path<F>(name: &str, op: F) -> Result<()>
+fn for_matching_path<F, T>(name: &str, op: F) -> Result<T>
 where
-    F: FnOnce(&PathBuf) -> Result<()>,
+    F: FnOnce(&PathBuf) -> Result<T>,
 {
     let err = Err(Error::new(ErrorKind::NotFound, "command not found"));
 
     // if the name already includes path separator, we should not try to do a PATH search on it
     // as it's likely an absolutely or relative name, so we treat it as such.
-    if name.contains(std::path::MAIN_SEPARATOR) {
+    if name.contains(MAIN_SEPARATOR) {
         let pb = std::path::PathBuf::from(name);
         if let Ok(metadata) = pb.metadata() {
             if metadata.is_file() && metadata.permissions().mode() & 0o111 != 0 {
@@ -212,10 +356,12 @@ fn run_command(cmd: &mut Command, background: bool, options: &BrowserOptions) ->
     // if dry_run, we return a true, as executable existence check has
     // already been done
     if options.dry_run {
+        debug!("dry-run enabled, so not running: {:?}", &cmd);
         return Ok(());
     }
 
     if background {
+        debug!("background spawn: {:?}", &cmd);
         // if we're in background, set stdin/stdout to null and spawn a child, as we're
         // not supposed to have any interaction.
         if options.suppress_output {
@@ -228,6 +374,7 @@ fn run_command(cmd: &mut Command, background: bool, options: &BrowserOptions) ->
         .spawn()
         .map(|_| ())
     } else {
+        debug!("foreground exec: {:?}", &cmd);
         // if we're in foreground, use status() instead of spawn(), as we'd like to wait
         // till completion.
         // We also specifically don't supress anything here, because we're running here
@@ -248,3 +395,8 @@ fn run_command(cmd: &mut Command, background: bool, options: &BrowserOptions) ->
 static TEXT_BROWSERS: [&str; 9] = [
     "lynx", "links", "links2", "elinks", "w3m", "eww", "netrik", "retawq", "curl",
 ];
+
+#[cfg(test)]
+pub mod tests_xdg {
+    pub use super::*;
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -33,8 +33,10 @@ where
         tx: Arc::new(tx.clone()),
     };
     let http_server = HttpServer::new(move || {
+        let wasm_pkg_dir = "tests/test-wasm-app/pkg";
+        let _ = std::fs::create_dir_all(std::path::Path::new(wasm_pkg_dir));
         App::new()
-            .service(fs::Files::new("/static/wasm", "tests/test-wasm-app/pkg"))
+            .service(fs::Files::new("/static/wasm", wasm_pkg_dir))
             .app_data(web::Data::new(data.clone()))
             .default_service(web::to(log_handler))
     })

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -23,6 +23,9 @@ pub async fn check_request_received_using<F>(uri: String, host: &str, op: F)
 where
     F: FnOnce(&str),
 {
+    // initialize env logger
+    let _ = env_logger::try_init();
+
     // start the server on a random port
     let bind_addr = format!("{}:0", host);
     let (tx, rx) = cbc::bounded(2);


### PR DESCRIPTION
See #55 for details.

When we use `xdg-open` to open a local file instead of a URL, the local filetype associations are given precedence by `xdg-open`, which spoils our plans to open the browser if say, an editor, is associated with the local html file extensions.

This PR modifies this behaviour to use `xdg-settings` to detect the default browser, and opens that browser bypassing any local file associations.