### PR TITLE
Remove `windows` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,7 @@ url = "2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3"
-features = [
-  'Window'
-]
+features = ['Window']
 
 [features]
 hardened = []
@@ -31,9 +29,6 @@ dirs = "4.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"
-
-[target.'cfg(windows)'.dependencies]
-windows = { version = "0.44.0", features = ["Win32_UI_Shell"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.20"


### PR DESCRIPTION
I noticed when bumping the dependency on this crate due to a CVE that it now used the `windows` crate. This is...a vast amount of overkill for 1 function and two constants. This just adds the _one_ binding needed by this crate and avoids the massive windows dependency altogether.