### PR TITLE
Use correct call convention for AssocQueryStringW()

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -7,7 +7,7 @@ const ASSOCF_IS_PROTOCOL: u32 = 0x00001000;
 const ASSOCSTR_COMMAND: i32 = 1;
 
 #[link(name = "shlwapi")]
-extern "C" {
+extern "system" {
     fn AssocQueryStringW(
         flags: u32,
         string: i32,


### PR DESCRIPTION
Fixes a minor issue introduced by #62 that broke build on 32-bit Windows targets.