### PR TITLE
Bail from `try_xdg` if browser name is empty

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -236,6 +236,9 @@ fn try_xdg(options: &BrowserOptions, url: &str) -> Result<()> {
         .map_err(|_| Error::new(ErrorKind::NotFound, "invalid default browser name"))?
         .trim()
         .to_owned();
+    if browser_name.is_empty() {
+        return Err(Error::new(ErrorKind::NotFound, "no default xdg browser"));
+    }
     trace!("found xdg browser: {:?}", &browser_name);
 
     // search for the config file corresponding to this browser name


### PR DESCRIPTION
Hey, not sure if I'm horribly off the mark. Had an infinite loop in WSL with the following on main branch:
```rust
fn main() -> Result<(), std::io::Error> {
    println!("HI");
    webbrowser::open("https://youtube.com")?;
    println!("BYE");
    Ok(())
}
```
There was apparently no default for browser in xdg settings:
![image](https://user-images.githubusercontent.com/25255817/215368248-1b1cab18-a6e8-4afa-96cf-08fe418812f1.png)

This causes an infinite loop because `open_using_xdg_config` ends up opening a directory and https://github.com/rust-lang/rust/issues/64144?

Fixed it by simply bailing if there is no name.
