### PR TITLE
tests/android: Use `adb reverse` to access host webserver, allow running on !macos

### DIFF
--- a/tests/common.rs
+++ b/tests/common.rs
@@ -44,7 +44,7 @@ async fn delayed_response(req: HttpRequest) -> impl Responder {
 
 pub async fn check_request_received_using<F>(uri: String, host: &str, op: F)
 where
-    F: FnOnce(&str),
+    F: FnOnce(&str, u16),
 {
     // initialize env logger
     let _ = env_logger::try_init();
@@ -78,7 +78,7 @@ where
     tokio::spawn(server);
 
     // invoke the op
-    op(&format!("http://{}:{}{}", host, port, &uri));
+    op(&format!("http://{}:{}{}", host, port, &uri), port);
 
     // wait for the url to be hit
     let timeout = 90;
@@ -93,7 +93,7 @@ where
 
 #[allow(dead_code)]
 pub async fn check_request_received(browser: Browser, uri: String) {
-    check_request_received_using(uri, "127.0.0.1", |url| {
+    check_request_received_using(uri, "127.0.0.1", |url, _port| {
         open_browser(browser, url).expect("failed to open browser");
     })
     .await;
@@ -110,7 +110,7 @@ where
     let id = rand::thread_rng().next_u32();
     let pb = html_dir.join(format!("test.{}.html", id));
     let img_uri = format!("{}?r={}", URI_PNG_1PX, id);
-    check_request_received_using(img_uri, "127.0.0.1", |uri| {
+    check_request_received_using(img_uri, "127.0.0.1", |uri, _port| {
         let url = url_op(&pb);
         let mut html_file = std::fs::File::create(&pb).expect("failed to create html file");
         html_file

--- a/tests/test-android-app/Cargo.toml
+++ b/tests/test-android-app/Cargo.toml
@@ -11,4 +11,3 @@ crate-type = ["lib", "cdylib"]
 jni = "0.19"
 ndk-glue = "0.7"
 webbrowser = { path = "../.." }
-

--- a/tests/test_ios.rs
+++ b/tests/test_ios.rs
@@ -30,7 +30,7 @@ mod tests {
         run_cmd(&glue_dir, "glue code build failed", &["./build"]);
 
         // invoke server
-        check_request_received_using(uri, &ipv4, |url| {
+        check_request_received_using(uri, &ipv4, |url, _port| {
             // modify ios app code to use the correct url
             let mut swift_src = PathBuf::from(&app_dir);
             swift_src.push("test-ios-app/ContentView.swift");

--- a/tests/test_wasm.rs
+++ b/tests/test_wasm.rs
@@ -17,7 +17,7 @@ mod tests {
     async fn test_wasm32() {
         let uri = &format!("/{}", TEST_PLATFORM);
         let ipv4 = "127.0.0.1";
-        check_request_received_using(uri.into(), ipv4, |url| {
+        check_request_received_using(uri.into(), ipv4, |url, _port| {
             // modify html to use the correct url
             let mut app_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             app_dir.push("tests/test-wasm-app");


### PR DESCRIPTION
Instead of chaining a bunch of Unix commands to pry out the IP address of a random adapter, that may not be available on every distro, use the standard `adb reverse` command to forward a specific port from the Android phone (or emulator) to the host, where the test-webserver is running.  This makes the test-script host-independent (should in theory run even on Windows now) and does not require the device at test (which could be a regular Android phone if not having an emulator running) to be connected to / reachable over the same network.
