### PR TITLE
Windows: Handle lack of quotes in browser command line

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -67,6 +67,7 @@ pub(super) fn open_browser_internal(
                     })?
             };
             trace!("default browser command: {}", &cmdline);
+            let cmdline = ensure_cmd_quotes(&cmdline);
             let mut cmd = get_browser_cmd(&cmdline, target)?;
             run_command(&mut cmd, true, options)
         }
@@ -75,6 +76,32 @@ pub(super) fn open_browser_internal(
             "Only the default browser is supported on this platform right now",
         )),
     }
+}
+
+/// It seems that sometimes browser exe paths which have spaces are not quoted, so we keep going over
+/// each token, until we encounter what looks like a valid exe.
+///
+/// See https://github.com/amodm/webbrowser-rs/issues/68
+fn ensure_cmd_quotes(cmdline: &str) -> String {
+    if !cmdline.starts_with('"') {
+        let mut end = 0;
+        for (idx, ch) in cmdline.char_indices() {
+            if ch == ' ' {
+                // does the path till now look like a valid exe?
+                let potential_exe = Path::new(&cmdline[..idx]);
+                if potential_exe.exists() {
+                    end = idx;
+                    break;
+                }
+            }
+        }
+        if end > 0 {
+            return format!("\"{}\"{}", &cmdline[..end], &cmdline[end..]);
+        }
+    }
+
+    // else we default to returning the original cmdline
+    cmdline.to_string()
 }
 
 /// Given the configured command line `cmdline` in registry, and the given `url`,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,6 +1,7 @@
 use crate::common::{for_each_token, run_command};
 use crate::{Browser, BrowserOptions, Error, ErrorKind, Result, TargetType};
 use log::trace;
+use std::path::Path;
 use std::process::Command;
 
 const ASSOCF_IS_PROTOCOL: u32 = 0x00001000;


### PR DESCRIPTION
It seems like in some cases, the browser command line as determined by `AssocQueryStringW` may not be appropriately quoted, e.g. [the case here](https://github.com/amodm/webbrowser-rs/issues/68#issuecomment-1503173266).

This PR modifies the behaviour on Windows to handle this situation, as follows:
1. If the command line has quotes, process normally
2. If the command line does not have quotes, keep trying spaced tokens until it feels like we've come across a valid exe (as determined by path existence), quote it, and process the revised command line.

Fixes #68 