### PR TITLE
chore: fix error message to be less misleading

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -82,7 +82,7 @@ fn open_browser_default(target: &TargetType, options: &BrowserOptions) -> Result
         .map_err(|_| {
             Error::new(
                 ErrorKind::NotFound,
-                "No valid browsers detected. You can specify one in BROWSERS environment variable",
+                "No valid browsers detected. You can specify one in BROWSER environment variable",
             )
         })
         // and convert a successful result into a ()


### PR DESCRIPTION
Hi 👋

I'm a downstream user of this crate and I stumbled across the error message when no valid browser is found. (I only have librewolf installed and it's not caught by the defaults).

The error message is talking about setting the `BROWSERS` variable while the code is using the `BROWSER` variable.

This PR corrects the error message to be more useful. 