### PR TITLE
initial illumos support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ hardened = []
 disable-wsl = []
 wasm-console = ["web-sys/console"]
 
-[target.'cfg(any(target_os = "aix", target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "haiku"))'.dependencies]
+[target.'cfg(any(target_os = "aix", target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "haiku", target_os = "illumos"))'.dependencies]
 home = "0.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 //! | wasm     | ✅        | default only | ✅ |
 //! | haiku    | ✅ (experimental) | default only | ❌ |
 //! | aix      | ✅ (experimental) | default only | ❌ |
+//! | illumos  | ✅ (experimental) | default only | ❌ |
 //!
 //! ## Consistent Behaviour
 //! `webbrowser` defines consistent behaviour on all platforms as follows:
@@ -52,7 +53,8 @@
         target_os = "freebsd",
         target_os = "netbsd",
         target_os = "openbsd",
-        target_os = "haiku"
+        target_os = "haiku",
+        target_os = "illumos"
     ),
     path = "unix.rs"
 )]
@@ -68,11 +70,12 @@ mod os;
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "haiku",
+    target_os = "illumos",
     target_os = "ios",
     target_arch = "wasm32"
 )))]
 compile_error!(
-    "Only Windows, Mac OS, iOS, Linux, *BSD, Haiku, AIX and Wasm32 are currently supported"
+    "Only Windows, Mac OS, iOS, Linux, *BSD, Haiku, AIX, illumos and Wasm32 are currently supported"
 );
 
 #[cfg(any(
@@ -82,6 +85,7 @@ compile_error!(
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "haiku",
+    target_os = "illumos",
     target_os = "windows"
 ))]
 pub(crate) mod common;


### PR DESCRIPTION
Like in PR https://github.com/amodm/webbrowser-rs/pull/79 I hit this issue wile trying to build `tree-sitter` on `OmniOS` (an `illumos` distribution).

This is a headless development system, so no webbrowser available.
```
running 5 tests
test test_open_chrome ... ignored
test test_open_firefox ... ignored
test test_open_safari ... ignored
test test_open_webpositive ... ignored
test os::tests_xdg::test_xdg_open_local_file ... ok

test result: ok. 1 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 1.01s

     Running tests/common.rs (target/debug/deps/common-85fea5dcb22e6b1b)
```