### PR TITLE
Bump `core-foundation` dependency to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-console = ["web-sys/console"]
 home = "0.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-foundation = "0.9"
+core-foundation = "0.10"
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.21"


### PR DESCRIPTION
The inspiration was https://github.com/ruffle-rs/ruffle/pull/17944, where `gilrs-core` pulled in this new version, duplicating this crate.
However, there are many other crates depending on 0.9 still.