### PR TITLE
Add Solaris support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ hardened = []
 disable-wsl = []
 wasm-console = ["web-sys/console"]
 
-[target.'cfg(any(target_os = "aix", target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "haiku", target_os = "illumos"))'.dependencies]
+[target.'cfg(any(target_os = "aix", target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "haiku", target_os = "illumos", target_os = "solaris"))'.dependencies]
 home = "0.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
Hi, when trying to build sigstore on Solaris, I've hit an issue with webbrowser-rs not supporting it (as it needs the `home` crate). This minor change solves that issue.

Tests are green:
```
running 5 tests
test test_open_chrome ... ignored
test test_open_firefox ... ignored
test test_open_safari ... ignored
test test_open_webpositive ... ignored
test os::tests_xdg::test_xdg_open_local_file ... ok

test result: ok. 1 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 1.01s

     Running tests/common.rs (target/debug/deps/common-368bc0ade2ab6989)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_android.rs (target/debug/deps/test_android-bae4723d08ac0efc)

running 3 tests
test tests::test_android ... ignored
test tests::test_non_existence_safari ... ok
test tests::test_existence_default ... ok

test result: ok. 2 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.32s

     Running tests/test_ios.rs (target/debug/deps/test_ios-33d0202a2a5f4b1a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_macos.rs (target/debug/deps/test_macos-b7ccf04782123dd3)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_unix.rs (target/debug/deps/test_unix-67ee6936302778a0)

running 6 tests
test tests::test_non_existence_safari ... ok
test tests::test_existence_default ... ok
test tests::test_local_file_abs_path ... ok
test tests::test_local_file_uri ... ok
test tests::test_local_file_rel_path ... ok
test tests::test_open_default ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 28.11s

     Running tests/test_wasm.rs (target/debug/deps/test_wasm-17a823806d32e01b)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_windows.rs (target/debug/deps/test_windows-2aa956fe49cdf6c8)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests webbrowser

running 5 tests
test src/lib.rs - open (line 253) - compile ... ok
test src/lib.rs - open (line 260) - compile ... ok
test src/lib.rs - (line 7) - compile ... ok
test src/lib.rs - open_browser (line 275) - compile ... ok
test src/lib.rs - open_browser_with_options (line 293) - compile ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s
```