### PR TITLE
ios: prepare for `objc2` frameworks v0.3

### DIFF
--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: macos-latest
+    runs-on: macos-15
     if: ${{ !contains(github.event.head_commit.message, '#build-') || contains(github.event.head_commit.message, '#build-ios') }}
     strategy:
       matrix:
@@ -26,8 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Checkout
-      - name: Select Xcode 15.3
-        run: sudo xcode-select -s /Applications/Xcode_15.3.app/Contents/Developer
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
       - name: Install rust version
         run: |
           rustup install ${{ matrix.rust }} --profile minimal
@@ -37,8 +37,8 @@ jobs:
       - name: Configure and start iOS Simulator
         run: |
           set -e
-          IOSRUNTIME=com.apple.CoreSimulator.SimRuntime.iOS-17-4
-          IOSDEV=$(xcrun simctl list 2>&1 | grep com.apple.CoreSimulator.SimDeviceType.iPhone | grep -v ' SE ' | tail -n 1 | tr -d '()' | awk '{ print $NF }')
+          IOSRUNTIME=$(xcrun simctl list runtimes | grep SimRuntime.iOS | awk '{ print $NF }' | egrep 'iOS-[0-9]{2}-' | sort | tail -n 1)
+          IOSDEV=$(xcrun simctl list 2>&1 | grep com.apple.CoreSimulator.SimDeviceType.iPhone | awk '{ print $NF }' | tr -d '()' | egrep 'iPhone-[0-9]{2}$' | sort | tail -n 1)
           DEVID=$(xcrun simctl create iphone-latest $IOSDEV $IOSRUNTIME)
           echo "==== using device $IOSDEV, $IOSRUNTIME ===="
           xcrun simctl boot $DEVID

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,8 @@ ndk-context = "0.1"
 [target.'cfg(any(target_os = "ios", target_os = "tvos", target_os = "visionos"))'.dependencies]
 block2 = "0.5.0"
 objc2 = "0.5.1"
-objc2-foundation = { version = "0.2.0", features = [
+objc2-foundation = { version = "0.2.0", default-features = false, features = [
+    "std",
     "NSDictionary",
     "NSString",
     "NSURL",


### PR DESCRIPTION
The next version of `objc2-foundation` will have a bunch of default features enabled, see https://github.com/madsmtm/objc2/issues/627, so this PR pre-emptively disables them, so that your compile times down blow up once you upgrade to the next version (which is yet to be released, but will be soon).