### PR TITLE
ios: Upgrade to `objc2 0.6` and drop `block2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,8 @@ jni = "0.21"
 ndk-context = "0.1"
 
 [target.'cfg(any(target_os = "ios", target_os = "tvos", target_os = "visionos"))'.dependencies]
-block2 = "0.5.0"
-objc2 = "0.5.1"
-objc2-foundation = { version = "0.2.0", default-features = false, features = [
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", default-features = false, features = [
     "std",
     "NSDictionary",
     "NSString",


### PR DESCRIPTION
The impeding `objc2 0.6` release series was already hinted at in https://github.com/amodm/webbrowser-rs/pull/94, and is now finally available.

Even though there's a new `objc2-ui-kit` dependency available that represents the `UIApplication` type and its methods faithfully, there was a strong preference to cut down on the number of dependencies instead so its improved signature has been incorporated here.  By extension the `block2` crate was removed too by inlining a simple type definition just to be able to set the `Option<&Block>` to `None`.

CC @madsmtm 