### PR TITLE
macos: Migrate to `objc2-core-foundation`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["webbrowser", "browser"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.69"
 
 [dependencies]
 log = "0.4"
@@ -29,7 +29,14 @@ wasm-console = ["web-sys/console"]
 home = "0.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-foundation = "0.10"
+objc2-core-foundation = { version = "0.3", default-features = false, features = [
+    "std",
+    "CFArray",
+    "CFBase",
+    "CFError",
+    "CFString",
+    "CFURL",
+] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.21"


### PR DESCRIPTION
All tests succeed. Opening as draft because there are no helpers yet an all functions have to be called on a low level with no safety abstractions. Following up on #95 because I upgraded `objc2` dependencies for iOS but noticed we could just as well utilize the new `objc2` CF crate for MacOS now.

The [`objc2-core-servcies` crate is empty as of yet](https://docs.rs/objc2-core-services/0.0.0/objc2_core_services/index.html) so all these external functions remain defined in-line.

CC @madsmtm 