### PR TITLE
ios: Check we're on the main thread before opening URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,9 @@ jni = "0.21"
 ndk-context = "0.1"
 
 [target.'cfg(any(target_os = "ios", target_os = "tvos", target_os = "visionos"))'.dependencies]
-block2 = "0.5.0"
-objc2 = "0.5.1"
-objc2-foundation = { version = "0.2.0", default-features = false, features = [
+block2 = "0.6.0"
+objc2 = "0.6.0"
+objc2-foundation = { version = "0.3.0", default-features = false, features = [
     "std",
     "NSDictionary",
     "NSString",

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -1,12 +1,12 @@
 use crate::{Browser, BrowserOptions, Error, ErrorKind, Result, TargetType};
 use block2::Block;
-use objc2::rc::Id;
+use objc2::rc::Retained;
 use objc2::runtime::Bool;
-use objc2::{class, msg_send, msg_send_id};
+use objc2::{class, msg_send};
 use objc2_foundation::{NSDictionary, NSObject, NSString, NSURL};
 
-fn app() -> Option<Id<NSObject>> {
-    unsafe { msg_send_id![class!(UIApplication), sharedApplication] }
+fn app() -> Option<Retained<NSObject>> {
+    unsafe { msg_send![class!(UIApplication), sharedApplication] }
 }
 
 fn open_url(


### PR DESCRIPTION
[`-[UIApplication openURL:options:completionHandler:]`](https://developer.apple.com/documentation/uikit/uiapplication/open(_:options:completionhandler:)?language=objc) is not safe to use from a thread that is not the main thread, since `UIApplication` is marked as `NS_SWIFT_UI_ACTOR` in the header, and the method is not marked with `NS_SWIFT_NONISOLATED` (unlike e.g. [`canOpenURL:`](https://developer.apple.com/documentation/uikit/uiapplication/canopenurl(_:)?language=objc), which is also explicitly documented to be usable from off the main thread).

See also discussion in https://github.com/amodm/webbrowser-rs/pull/95, this check is present in `objc2-ui-kit`.

Builds upon https://github.com/amodm/webbrowser-rs/pull/97 to avoid a merge conflict.