### PR TITLE
Fix packed alignment of `LSLaunchURLSpec`

### DIFF
--- a/src/macos.rs
+++ b/src/macos.rs
@@ -170,7 +170,7 @@ const LSROLE_VIEWER: LSRolesMask = 0x00000002;
 const LS_LAUNCH_FLAG_DEFAULTS: u32 = 0x00000001;
 const LS_LAUNCH_FLAG_ASYNC: u32 = 0x00010000;
 
-#[repr(C)]
+#[repr(C, packed(2))] // Header contains `#pragma pack(push, 2)`.
 struct LSLaunchURLSpec {
     app_url: CFURLRef,
     item_urls: CFArrayRef,


### PR DESCRIPTION
`LSLaunchURLSpec` is defined in `src/macos.rs` as:
```rust
#[repr(C)]
struct LSLaunchURLSpec {
    app_url: CFURLRef,
    item_urls: CFArrayRef,
    pass_thru_params: *const c_void,
    launch_flags: u32,
    async_ref_con: *const c_void,
}
```

At a glance, you'd think this matches the definition in the C header:
```c
typedef struct LSLaunchURLSpec {
  __nullable CFURLRef appURL;
  __nullable CFArrayRef itemURLs;
  const AEDesc * __nullable passThruParams;
  LSLaunchFlags launchFlags;
  void * __nullable asyncRefCon;
} LSLaunchURLSpec;
```

However, there's a catch: the header contains `#pragma pack(push, 2)`, see [here](https://github.com/phracker/MacOSX-SDKs/blob/041600eda65c6a668f66cb7d56b7d1da3e8bcc93/MacOSX11.3.sdk/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Headers/LSOpen.h#L50), which means that the correct definition in Rust should correspondingly use `#[repr(C, packed(2))]`.

Effectively, the difference is that the 4 padding bytes that the compiler otherwise inserts between `launchFlags` and `asyncRefCon` shouldn't be there. This is somewhat unlikely to be an issue in practice, since the compiler will likely zero out the padding bytes; but if it decided not to, then `LSOpenFromURLSpec` would read a bogus `asyncRefCon` pointer.

Found this as part of fixing https://github.com/madsmtm/objc2/issues/758, and then I remembered that I had seen `LSLaunchURLSpec` used here too.