### PR TITLE
macos: add dont_switch flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,8 @@ pub struct BrowserOptions {
     suppress_output: bool,
     target_hint: String,
     dry_run: bool,
+    #[cfg(target_os = "macos")]
+    dont_switch: bool,
 }
 
 impl fmt::Display for BrowserOptions {
@@ -203,6 +205,8 @@ impl std::default::Default for BrowserOptions {
             suppress_output: true,
             target_hint,
             dry_run: false,
+            #[cfg(target_os = "macos")]
+            dont_switch: false,
         }
     }
 }
@@ -236,6 +240,13 @@ impl BrowserOptions {
     /// succeeded. Note the "likely" here - it's still indicative than guaranteed.
     pub fn with_dry_run(&mut self, dry_run: bool) -> &mut Self {
         self.dry_run = dry_run;
+        self
+    }
+
+    #[cfg(target_os = "macos")]
+    /// Do not switch to the browser window. This is macOS only right now.
+    pub fn with_dont_switch(&mut self, dont_switch: bool) -> &mut Self {
+        self.dont_switch = dont_switch;
         self
     }
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -55,11 +55,15 @@ pub(super) fn open_browser_internal(
 
     let urls_v = [cf_url];
     let urls_arr = CFArray::<CFURL>::from_CFTypes(&urls_v);
+    let mut launch_flags = LS_LAUNCH_FLAG_DEFAULTS | LS_LAUNCH_FLAG_ASYNC;
+    if options.dont_switch {
+        launch_flags |= LS_LAUNCH_FLAG_DONT_SWITCH;
+    }
     let spec = LSLaunchURLSpec {
         app_url: browser_cf_url.as_concrete_TypeRef(),
         item_urls: urls_arr.as_concrete_TypeRef(),
         pass_thru_params: std::ptr::null(),
-        launch_flags: LS_LAUNCH_FLAG_DEFAULTS | LS_LAUNCH_FLAG_ASYNC,
+        launch_flags,
         async_ref_con: std::ptr::null(),
     };
 
@@ -169,6 +173,7 @@ const LSROLE_VIEWER: LSRolesMask = 0x00000002;
 // as per https://developer.apple.com/documentation/coreservices/lslaunchflags/klslaunchdefaults?language=objc
 const LS_LAUNCH_FLAG_DEFAULTS: u32 = 0x00000001;
 const LS_LAUNCH_FLAG_ASYNC: u32 = 0x00010000;
+const LS_LAUNCH_FLAG_DONT_SWITCH: u32 = 0x00000200;
 
 #[repr(C, packed(2))] // Header contains `#pragma pack(push, 2)`.
 struct LSLaunchURLSpec {


### PR DESCRIPTION
Fixes #105

This PR introduces a `dont_switch` option specifically on macos (for now).