### PR TITLE
Fix opening a browser that is located in a path that contains unicode characters

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -12,7 +12,7 @@ where
     let mut in_quotes = false;
     let mut idx = 0;
     for ch in line.chars() {
-        idx += 1;
+        idx += ch.len_utf8();
         match ch {
             '"' => {
                 if let Some(start_idx) = start {


### PR DESCRIPTION
If there are unicode characters in the `line` variable, getting the substring by slicing: `line[start_idx..idx - 1]` doesn't return characters from start_idx to idx, but instead it returns characters that are stored on bytes from start_idx to idx. To prevent that, idx (as well as start_idx) needs to store byte position instead of character position.