### PR TITLE
HACK: windows: Work around broken `AssocQueryStringW()` not returning actual string length

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -57,8 +57,22 @@ pub(super) fn open_browser_internal(
                     ));
                 }
 
+                let mut line_len = line_len as usize;
+
+                // If line_len wasn't updated, this might be a broken AssocQueryStringW() implementation in wine:
+                // https://bugs.winehq.org/show_bug.cgi?id=59402
+                // In that case, find the NUL terminator ourselves.
+                if line_len == BUF_SIZE {
+                    if let Some(found_nul) = cmdline_u16.iter().position(|&c| c == 0) {
+                        trace!(
+                            "Broken AssocQueryStringW(), manually string length determined at {found_nul}"
+                        );
+                        line_len = found_nul + 1;
+                    }
+                }
+
                 use std::os::windows::ffi::OsStringExt;
-                std::ffi::OsString::from_wide(&cmdline_u16[..(line_len - 1) as usize])
+                std::ffi::OsString::from_wide(&cmdline_u16[..(line_len - 1)])
                     .into_string()
                     .map_err(|_err| {
                         Error::new(


### PR DESCRIPTION
Wine has a bug where calling `AssocQueryStringW()` with a buffer doesn't actually update `line_len` to the actual number of bytes returned, resulting in `webbrowser` failing on seeing a bunch of unexpected `nul` bytes in the array:

    Error { kind: InvalidInput, message: "nul byte found in provided data" }

This is reported and fixed upstream via:

https://bugs.winehq.org/show_bug.cgi?id=59402
https://gitlab.winehq.org/wine/wine/-/merge_requests/10072

I still need to write tests to get it merged, and even then it might take a while to trickle down into releases and ultimately Steam Proton. Hence have this ugly workaround to catch cases where `nul` characters end up in the output and reduce the string length by hand.