### PR TITLE
Move to objc2 for macos

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -31,6 +31,25 @@ jobs:
           rustup component add --toolchain ${{ matrix.rust }} rustfmt clippy
       - name: Compile
         run: cargo +${{ matrix.rust }} build
+      - name: Warm up Chrome (leave a flagged instance running for the tests)
+        # On the Sequoia runner, a cold GUI Chrome launched via LaunchServices
+        # never gets past its first-run flow to navigate to the URL (verified:
+        # headless Chrome with automation flags reaches a local server, but a
+        # cold LaunchServices open does not - and LaunchServices can't pass those
+        # flags). So we start a persistent Chrome instance here WITH the flags and
+        # leave it running; when test_open_chrome does its LaunchServices open,
+        # the URL is handed to this already-initialised instance, which navigates
+        # normally. Launched in the background so this step can't hang on a modal,
+        # and deliberately NOT killed so it survives into the test step.
+        run: |
+          nohup "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+            --no-first-run --no-default-browser-check \
+            --use-mock-keychain --password-store=basic \
+            about:blank >chrome-warmup.log 2>&1 &
+          disown || true
+          sleep 10
+          echo "Chrome warm-up launched; running processes:"
+          ps ax -o pid,command | grep -i "[G]oogle Chrome" | head -5 || echo "none"
       - name: Run Tests
         run: cargo +${{ matrix.rust }} test --locked --verbose --test test_macos -- --include-ignored
       - name: Run Tests (hardened)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,19 @@ disable-wsl = []
 wasm-console = ["web-sys/console"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-foundation = "0.10"
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", default-features = false, features = [
+    "std",
+    "NSArray",
+    "NSString",
+    "NSURL",
+] }
+objc2-app-kit = { version = "0.3", default-features = false, features = [
+    "std",
+    "block2",
+    "NSWorkspace",
+    "NSRunningApplication",
+] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.22.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,13 @@ objc2 = "0.6"
 objc2-foundation = { version = "0.3", default-features = false, features = [
     "std",
     "NSArray",
+    "NSDictionary",
+    "NSError",
     "NSString",
     "NSURL",
 ] }
 objc2-app-kit = { version = "0.3", default-features = false, features = [
     "std",
-    "block2",
     "NSWorkspace",
     "NSRunningApplication",
 ] }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -64,12 +64,14 @@ pub(super) fn open_browser_internal(
             &config,
         )
     };
-    result.map(|_running_app| ()).map_err(map_launch_error)
+    result
+        .map(|_running_app| ())
+        .map_err(|err| map_launch_error(&err))
 }
 
 /// Maps an `NSError` returned while launching the browser to our [`Error`] type,
 /// preserving the `NotFound`/`PermissionDenied` distinctions where possible.
-fn map_launch_error(err: objc2::rc::Retained<NSError>) -> Error {
+fn map_launch_error(err: &NSError) -> Error {
     // For the `NSOSStatusErrorDomain`, `code` is the underlying Launch Services
     // `OSStatus`. See the `Result Codes` section of:
     // https://developer.apple.com/documentation/coreservices/launch_services

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,8 +1,11 @@
 use crate::{Browser, BrowserOptions, Error, ErrorKind, Result, TargetType};
-use objc2_app_kit::{NSWorkspace, NSWorkspaceOpenConfiguration};
-use objc2_foundation::{NSArray, NSString, NSURL};
+use objc2_app_kit::{NSWorkspace, NSWorkspaceLaunchOptions};
+use objc2_foundation::{NSArray, NSDictionary, NSError, NSString, NSURL};
 
 /// Deal with opening of browsers on macOS using the AppKit `NSWorkspace` APIs.
+// We intentionally use the deprecated synchronous launch API (see the note at
+// the launch site below), so silence the deprecation warnings for this fn.
+#[allow(deprecated)]
 pub(super) fn open_browser_internal(
     browser: Browser,
     target: &TargetType,
@@ -38,19 +41,45 @@ pub(super) fn open_browser_internal(
         .ok_or_else(|| Error::other("failed to create target NSURL"))?;
     let urls = NSArray::from_retained_slice(&[target_url]);
 
-    // configure the launch
-    let config = NSWorkspaceOpenConfiguration::configuration();
+    // configure the launch. We use the (deprecated) synchronous launch API
+    // rather than the newer completion-handler based one, as the latter relies
+    // on the caller running a main run loop to actually dispatch the launch,
+    // which isn't the case for library consumers (and breaks in headless
+    // environments such as CI). This is the direct equivalent of the Launch
+    // Services `LSOpenFromURLSpec` call we previously used.
+    let mut launch_options = NSWorkspaceLaunchOptions::Default;
     if options.dont_switch {
         // don't bring the browser to the foreground
-        config.setActivates(false);
+        launch_options |= NSWorkspaceLaunchOptions::WithoutActivation;
     }
+    let config = NSDictionary::new();
 
     // launch the browser
     log::trace!("about to start browser: {browser} for {target}");
-    workspace.openURLs_withApplicationAtURL_configuration_completionHandler(
-        &urls, &app_url, &config, None,
-    );
-    Ok(())
+    let result = unsafe {
+        workspace.openURLs_withApplicationAtURL_options_configuration_error(
+            &urls,
+            &app_url,
+            launch_options,
+            &config,
+        )
+    };
+    result.map(|_running_app| ()).map_err(map_launch_error)
+}
+
+/// Maps an `NSError` returned while launching the browser to our [`Error`] type,
+/// preserving the `NotFound`/`PermissionDenied` distinctions where possible.
+fn map_launch_error(err: objc2::rc::Retained<NSError>) -> Error {
+    // For the `NSOSStatusErrorDomain`, `code` is the underlying Launch Services
+    // `OSStatus`. See the `Result Codes` section of:
+    // https://developer.apple.com/documentation/coreservices/launch_services
+    let kind = match err.code() {
+        // -43 is file not found, while -10814 is launch services err code
+        -43 | -10814 => ErrorKind::NotFound,
+        -10826 => ErrorKind::PermissionDenied,
+        _ => ErrorKind::Other,
+    };
+    Error::new(kind, err.localizedDescription().to_string())
 }
 
 /// Determine the URL of the user's default browser, falling back to Safari if

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,207 +1,92 @@
 use crate::{Browser, BrowserOptions, Error, ErrorKind, Result, TargetType};
-use core_foundation::array::{CFArray, CFArrayRef};
-use core_foundation::base::TCFType;
-use core_foundation::error::{CFError, CFErrorRef};
-use core_foundation::url::{CFURLRef, CFURL};
-use std::os::raw::c_void;
+use objc2_app_kit::{NSWorkspace, NSWorkspaceOpenConfiguration};
+use objc2_foundation::{NSArray, NSString, NSURL};
 
-/// Deal with opening of browsers on Mac OS X using Core Foundation framework
+/// Deal with opening of browsers on macOS using the AppKit `NSWorkspace` APIs.
 pub(super) fn open_browser_internal(
     browser: Browser,
     target: &TargetType,
     options: &BrowserOptions,
 ) -> Result<()> {
-    // create the CFUrl for the browser
-    let browser_cf_url = match browser {
-        Browser::Firefox => create_cf_url("file:///Applications/Firefox.app/"),
-        Browser::Chrome => create_cf_url("file:///Applications/Google Chrome.app/"),
-        Browser::Opera => create_cf_url("file:///Applications/Opera.app/"),
-        Browser::Safari => create_cf_url("file:///Applications/Safari.app/"),
-        Browser::Default => {
-            if let Some(dummy_url) = create_cf_url("https://") {
-                let mut err: CFErrorRef = std::ptr::null_mut();
-                let result = unsafe {
-                    LSCopyDefaultApplicationURLForURL(
-                        dummy_url.as_concrete_TypeRef(),
-                        LSROLE_VIEWER,
-                        &mut err,
-                    )
-                };
-                if result.is_null() {
-                    log::error!("failed to get default browser: {}", unsafe {
-                        CFError::wrap_under_create_rule(err)
-                    });
-                    create_cf_url(DEFAULT_BROWSER_URL)
-                } else {
-                    let cf_url = unsafe { CFURL::wrap_under_create_rule(result) };
-                    log::trace!("default browser is {cf_url:?}");
-                    Some(cf_url)
-                }
-            } else {
-                create_cf_url(DEFAULT_BROWSER_URL)
-            }
-        }
+    let workspace = NSWorkspace::sharedWorkspace();
+
+    // Resolve the URL of the browser application we want to launch. Rather than
+    // relying on hardcoded application paths, we locate applications by their
+    // bundle identifiers (or, for the default browser, ask the system which
+    // application handles https urls).
+    let app_url = match browser {
+        Browser::Default => resolve_default_browser(&workspace),
         _ => {
-            return Err(Error::new(
-                ErrorKind::NotFound,
-                "browser not supported on macos",
-            ))
+            let bundle_id = bundle_id_for_browser(browser)
+                .ok_or_else(|| Error::new(ErrorKind::NotFound, "browser not supported on macos"))?;
+            let bundle_id = NSString::from_str(bundle_id);
+            workspace.URLForApplicationWithBundleIdentifier(&bundle_id)
         }
     }
-    .ok_or_else(|| Error::other("failed to create CFURL"))?;
+    .ok_or_else(|| Error::new(ErrorKind::NotFound, "browser not found"))?;
 
-    let cf_url =
-        create_cf_url(target.as_ref()).ok_or_else(|| Error::other("failed to create CFURL"))?;
-
-    let urls_v = [cf_url];
-    let urls_arr = CFArray::<CFURL>::from_CFTypes(&urls_v);
-    let mut launch_flags = LS_LAUNCH_FLAG_DEFAULTS | LS_LAUNCH_FLAG_ASYNC;
-    if options.dont_switch {
-        launch_flags |= LS_LAUNCH_FLAG_DONT_SWITCH;
-    }
-    let spec = LSLaunchURLSpec {
-        app_url: browser_cf_url.as_concrete_TypeRef(),
-        item_urls: urls_arr.as_concrete_TypeRef(),
-        pass_thru_params: std::ptr::null(),
-        launch_flags,
-        async_ref_con: std::ptr::null(),
-    };
-
-    // handle dry-run scenario
+    // handle dry-run scenario: the application was located above, so we know it
+    // exists without actually launching it.
     if options.dry_run {
-        return if let Some(path) = browser_cf_url.to_path() {
-            if path.is_dir() {
-                log::debug!("dry-run: not actually opening the browser {browser}");
-                Ok(())
-            } else {
-                log::debug!("dry-run: browser {browser} not found");
-                Err(Error::new(ErrorKind::NotFound, "browser not found"))
-            }
-        } else {
-            Err(Error::other("unable to convert app url to path"))
-        };
+        log::debug!("dry-run: not actually opening the browser {browser}");
+        return Ok(());
+    }
+
+    // create the NSURL for the target we want to open
+    let target_string = NSString::from_str(target.as_ref());
+    let target_url = NSURL::URLWithString(&target_string)
+        .ok_or_else(|| Error::other("failed to create target NSURL"))?;
+    let urls = NSArray::from_retained_slice(&[target_url]);
+
+    // configure the launch
+    let config = NSWorkspaceOpenConfiguration::configuration();
+    if options.dont_switch {
+        // don't bring the browser to the foreground
+        config.setActivates(false);
     }
 
     // launch the browser
     log::trace!("about to start browser: {browser} for {target}");
-    let mut launched_app: CFURLRef = std::ptr::null_mut();
-    let status = unsafe { LSOpenFromURLSpec(&spec, &mut launched_app) };
-    log::trace!("received status: {status}");
-    if status == 0 {
-        Ok(())
-    } else {
-        Err(Error::from(LSError::from(status)))
-    }
+    workspace.openURLs_withApplicationAtURL_configuration_completionHandler(
+        &urls, &app_url, &config, None,
+    );
+    Ok(())
 }
 
-/// Create a Core Foundation CFURL object given a rust-y `url`
-fn create_cf_url(url: &str) -> Option<CFURL> {
-    let url_u8 = url.as_bytes();
-    let url_ref = unsafe {
-        core_foundation::url::CFURLCreateWithBytes(
-            std::ptr::null(),
-            url_u8.as_ptr(),
-            url_u8.len() as isize,
-            core_foundation::string::kCFStringEncodingUTF8,
-            std::ptr::null(),
-        )
-    };
+/// Determine the URL of the user's default browser, falling back to Safari if
+/// detection fails for any reason.
+fn resolve_default_browser(workspace: &NSWorkspace) -> Option<objc2::rc::Retained<NSURL>> {
+    let https = NSString::from_str("https://");
+    let resolved =
+        NSURL::URLWithString(&https).and_then(|url| workspace.URLForApplicationToOpenURL(&url));
 
-    if url_ref.is_null() {
-        None
-    } else {
-        Some(unsafe { CFURL::wrap_under_create_rule(url_ref) })
-    }
-}
-
-type OSStatus = i32;
-
-/// A subset of Launch Services error codes as picked from (`Result Codes` section)
-/// https://developer.apple.com/documentation/coreservices/launch_services?language=objc#1661359
-enum LSError {
-    Unknown(OSStatus),
-    ApplicationNotFound,
-    NoLaunchPermission,
-}
-
-impl From<OSStatus> for LSError {
-    fn from(status: OSStatus) -> Self {
-        match status {
-            // -43 is file not found, while -10814 is launch services err code
-            -43 | -10814 => Self::ApplicationNotFound,
-            -10826 => Self::NoLaunchPermission,
-            _ => Self::Unknown(status),
+    match resolved {
+        Some(url) => {
+            log::trace!("default browser is {url:?}");
+            Some(url)
+        }
+        None => {
+            log::error!("failed to get default browser, falling back to Safari");
+            let safari = NSString::from_str(SAFARI_BUNDLE_ID);
+            workspace.URLForApplicationWithBundleIdentifier(&safari)
         }
     }
 }
 
-impl std::fmt::Display for LSError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Unknown(code) => write!(f, "ls_error: code {code}"),
-            Self::ApplicationNotFound => f.write_str("ls_error: application not found"),
-            Self::NoLaunchPermission => f.write_str("ls_error: no launch permission"),
-        }
+/// Maps a [`Browser`] to its macOS bundle identifier. Returns `None` for
+/// browsers that aren't supported on macOS.
+fn bundle_id_for_browser(browser: Browser) -> Option<&'static str> {
+    match browser {
+        Browser::Firefox => Some("org.mozilla.firefox"),
+        Browser::Chrome => Some("com.google.Chrome"),
+        Browser::Opera => Some("com.operasoftware.Opera"),
+        Browser::Safari => Some(SAFARI_BUNDLE_ID),
+        _ => None,
     }
-}
-
-impl std::fmt::Debug for LSError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(self, f)
-    }
-}
-
-impl From<LSError> for Error {
-    fn from(err: LSError) -> Self {
-        let kind = match err {
-            LSError::Unknown(_) => ErrorKind::Other,
-            LSError::ApplicationNotFound => ErrorKind::NotFound,
-            LSError::NoLaunchPermission => ErrorKind::PermissionDenied,
-        };
-        Error::new(kind, err.to_string())
-    }
-}
-
-type LSRolesMask = u32;
-
-// as per https://developer.apple.com/documentation/coreservices/lsrolesmask/klsrolesviewer?language=objc
-const LSROLE_VIEWER: LSRolesMask = 0x00000002;
-
-// as per https://developer.apple.com/documentation/coreservices/lslaunchflags/klslaunchdefaults?language=objc
-const LS_LAUNCH_FLAG_DEFAULTS: u32 = 0x00000001;
-const LS_LAUNCH_FLAG_ASYNC: u32 = 0x00010000;
-const LS_LAUNCH_FLAG_DONT_SWITCH: u32 = 0x00000200;
-
-#[repr(C, packed(2))] // Header contains `#pragma pack(push, 2)`.
-struct LSLaunchURLSpec {
-    app_url: CFURLRef,
-    item_urls: CFArrayRef,
-    pass_thru_params: *const c_void,
-    launch_flags: u32,
-    async_ref_con: *const c_void,
-}
-
-// Define the functions in CoreServices that we'll be using to open the browser
-#[link(name = "CoreServices", kind = "framework")]
-extern "C" {
-    /// Used to get the default browser configured for the user. See:
-    /// https://developer.apple.com/documentation/coreservices/1448824-lscopydefaultapplicationurlforur?language=objc
-    fn LSCopyDefaultApplicationURLForURL(
-        inURL: CFURLRef,
-        inRoleMask: LSRolesMask,
-        outError: *mut CFErrorRef,
-    ) -> CFURLRef;
-
-    /// Used to launch the browser to open a url
-    /// https://developer.apple.com/documentation/coreservices/1441986-lsopenfromurlspec?language=objc
-    fn LSOpenFromURLSpec(
-        inLaunchSpec: *const LSLaunchURLSpec,
-        outLaunchedURL: *mut CFURLRef,
-    ) -> OSStatus;
 }
 
 /// We assume Safari to be the default browser, if deductions fail for any reason
-const DEFAULT_BROWSER_URL: &str = "file:///Applications/Safari.app/";
+const SAFARI_BUNDLE_ID: &str = "com.apple.Safari";
 
 #[cfg(test)]
 mod tests {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -55,7 +55,7 @@ pub(super) fn open_browser_internal(
     let config = NSDictionary::new();
 
     // launch the browser
-    log::trace!("about to start browser: {browser} for {target}");
+    log::trace!("about to start browser: {browser} for {target} using app at {app_url:?}");
     let result = unsafe {
         workspace.openURLs_withApplicationAtURL_options_configuration_error(
             &urls,
@@ -64,9 +64,18 @@ pub(super) fn open_browser_internal(
             &config,
         )
     };
-    result
-        .map(|_running_app| ())
-        .map_err(|err| map_launch_error(&err))
+    match result {
+        Ok(running_app) => {
+            log::trace!(
+                "launched {browser}: bundle_id={:?}, url={:?}, finished_launching={}",
+                running_app.bundleIdentifier(),
+                running_app.bundleURL(),
+                running_app.isFinishedLaunching(),
+            );
+            Ok(())
+        }
+        Err(err) => Err(map_launch_error(&err)),
+    }
 }
 
 /// Maps an `NSError` returned while launching the browser to our [`Error`] type,

--- a/tests/test_macos.rs
+++ b/tests/test_macos.rs
@@ -6,25 +6,30 @@ mod tests {
     const TEST_PLATFORM: &str = "macos";
 
     use super::common::*;
+    use serial_test::serial;
     use webbrowser::Browser;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial]
     async fn test_open_default() {
         check_browser(Browser::Default, TEST_PLATFORM).await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial]
     async fn test_open_safari() {
         check_browser(Browser::Safari, TEST_PLATFORM).await;
     }
 
     // #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    // #[serial]
     // #[ignore]
     // async fn test_open_firefox() {
     //     check_browser(Browser::Firefox, TEST_PLATFORM).await;
     // }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial]
     #[ignore]
     async fn test_open_chrome() {
         check_browser(Browser::Chrome, TEST_PLATFORM).await;
@@ -50,6 +55,7 @@ mod tests {
 
     #[cfg(not(feature = "hardened"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial]
     async fn test_local_file_abs_path() {
         check_local_file(Browser::Default, None, |pb| {
             pb.as_os_str().to_string_lossy().into()
@@ -59,6 +65,7 @@ mod tests {
 
     #[cfg(not(feature = "hardened"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial]
     async fn test_local_file_rel_path() {
         let cwd = std::env::current_dir().expect("unable to get current dir");
         check_local_file(Browser::Default, None, |pb| {
@@ -73,6 +80,7 @@ mod tests {
 
     #[cfg(not(feature = "hardened"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial]
     async fn test_local_file_uri() {
         check_local_file(Browser::Default, None, |pb| {
             url::Url::from_file_path(pb)


### PR DESCRIPTION
This PR does the following:
- move macos to use `objc2` instead of `core-foundation`
- use application bundle ids instead of hardcoded application paths